### PR TITLE
Specify which service to pull and update.

### DIFF
--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -135,9 +135,10 @@ if [ -n "$GotUpdates" ] ; then
   if [ "$UpdYes" != "${UpdYes#[Yy]}" ] ; then
     for i in "${SelectedUpdates[@]}"
     do 
-      ContPath=$(docker inspect "$i" --format '{{ index .Config.Labels "com.docker.compose.project.config_files"}}')
-      $DockerBin -f "$ContPath" pull "$i"
-      $DockerBin -f "$ContPath" up -d "$i"
+      ContPath=$(docker inspect "$i" --format '{{ index .Config.Labels "com.docker.compose.project.config_files" }}')
+      ContName=$(docker inspect "$i" --format '{{ index .Config.Labels "com.docker.compose.service" }}')
+      $DockerBin -f "$ContPath" pull "$ContName"
+      $DockerBin -f "$ContPath" up -d "$ContName"
     done
   else
     printf "\nNo updates installed, exiting.\n"

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -136,8 +136,8 @@ if [ -n "$GotUpdates" ] ; then
     for i in "${SelectedUpdates[@]}"
     do 
       ContPath=$(docker inspect "$i" --format '{{ index .Config.Labels "com.docker.compose.project.config_files"}}')
-      $DockerBin -f "$ContPath" pull 
-      $DockerBin -f "$ContPath" up -d
+      $DockerBin -f "$ContPath" pull "$i"
+      $DockerBin -f "$ContPath" up -d "$i"
     done
   else
     printf "\nNo updates installed, exiting.\n"


### PR DESCRIPTION
Currently if you have multiple services that have updates in one docker-compose.yml file, the script updates all the services in the file which might not be what the user chose.

This just specifies the service in the commands.