### PR TITLE
Execute up command from the compose file folder

### DIFF
--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -165,6 +165,7 @@ if [ -n "$GotUpdates" ] ; then
       else
         ComposeFile="$ContPath/$ContConfigFile"
       fi
+      cd "$(dirname "${ComposeFile}")"
       $DockerBin -f "$ComposeFile" pull "$ContName"
       $DockerBin -f "$ComposeFile" up -d "$ContName"
     done


### PR DESCRIPTION
Hi, 

First of all, thanks for this really cool script.

I'm using a special structure for my containers, in the case of relative paths inside docker-compose.yml file, things can break, for example:

```
├── docker-compose.yml
└── storage
    ├── vol1
    └── vol2
```

```yml
services:
  some_app:
    volumes:
      - $PWD/storage/vol1:/vol1
      - $PWD/storage/vol2:/vol2
```

Hope this helps,

Regards,
F0x

