### PR TITLE
Execute script in the script's path

### DIFF
--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+cd "$(dirname "$0")"
 VERSION="v0.2.5"
 ### ChangeNotes: Added an -s option to include stopped contianers in the check.
 Github="https://github.com/mag37/dockcheck"


### PR DESCRIPTION
`cd`s into the script's directory. The goal was to be able to run the script from anywhere without having the `regctl` binary downloaded to where it's called and this was the simplest way. It's often a good idea in other cases too.