### PR TITLE
add a generic sample notification and a DSM notification addon

### DIFF
--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -14,6 +14,8 @@ ScriptWorkDir="$(dirname "$ScriptPath")"
 LatestRelease="$(curl -s -r 0-50 $RawUrl | sed -n "/VERSION/s/VERSION=//p" | tr -d '"')"
 LatestChanges="$(curl -s -r 0-200 $RawUrl | sed -n "/ChangeNotes/s/### ChangeNotes: //p")"
 
+[ -s $ScriptWorkDir/notify.sh ] && source $ScriptWorkDir/notify.sh
+
 ### Help Function:
 Help() {
   echo "Syntax:     dockcheck.sh [OPTION] [part of name to filter]" 
@@ -232,6 +234,7 @@ fi
 if [[ -n ${GotUpdates[*]} ]] ; then 
    printf "\n%bContainers with updates available:%b\n" "$c_yellow" "$c_reset"
    [[ -z "$AutoUp" ]] && options || printf "%s\n" "${GotUpdates[@]}"
+   [[ $(type -t send_notification) == function ]] && send_notification ${GotUpdates[@]}
 fi
 
 ### Optionally get updates if there's any 

--- a/notify_DSM.sh
+++ b/notify_DSM.sh
@@ -15,15 +15,15 @@ ssmtp $SendMailTo << __EOF
 From: "$FromHost" <$SendMailTo>
 date:$(date -R)
 To: <$SendMailTo>
-Subject: [diskstation] Some docker packages need to be updated
+Subject: [diskstation] Some docker containers need to be updated
 Content-Type: text/plain; charset=UTF-8; format=flowed
 Content-Transfer-Encoding: 7bit
 
-The following docker packages on $FromHost need to be updated:
+The following docker containers on $FromHost need to be updated:
 
-"$UpdToString"
+$UpdToString
 
-From $FromHost
+ From $FromHost
 
 __EOF
 }

--- a/notify_DSM.sh
+++ b/notify_DSM.sh
@@ -1,7 +1,8 @@
 # copy/rename this file to notify.sh to enable email notifications on synology DSM
 
 send_notification() {
-
+Updates=("$@")
+UpdToString=$( printf "%s\n" "${Updates[@]}" )
 # change this to your usual destination for synology DSM notification emails
 SendMailTo=me@mydomain.com
 FromHost=$(hostname)
@@ -18,8 +19,9 @@ Content-Transfer-Encoding: 7bit
 
 The following docker packages on $FromHost need to be updated:
 
-$@
+"$UpdToString"
 
- From $FromHost
+From $FromHost
+
 __EOF
 }

--- a/notify_DSM.sh
+++ b/notify_DSM.sh
@@ -1,4 +1,6 @@
-# copy/rename this file to notify.sh to enable email notifications on synology DSM
+### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
+# Copy/rename this file to notify.sh to enable email notifications on synology DSM
+# Modify to your liking - changing SendMailTo and Subject and content.
 
 send_notification() {
 Updates=("$@")

--- a/notify_DSM.sh
+++ b/notify_DSM.sh
@@ -1,0 +1,25 @@
+# copy/rename this file to notify.sh to enable email notifications on synology DSM
+
+send_notification() {
+
+# change this to your usual destination for synology DSM notification emails
+SendMailTo=me@mydomain.com
+FromHost=$(hostname)
+
+printf "\nSending email notification\n"
+
+ssmtp $SendMailTo << __EOF
+From: "$FromHost" <$SendMailTo>
+date:$(date -R)
+To: <$SendMailTo>
+Subject: [diskstation] Some docker packages need to be updated
+Content-Type: text/plain; charset=UTF-8; format=flowed
+Content-Transfer-Encoding: 7bit
+
+The following docker packages on $FromHost need to be updated:
+
+$@
+
+ From $FromHost
+__EOF
+}

--- a/notify_generic.sh
+++ b/notify_generic.sh
@@ -2,11 +2,11 @@
 # generic sample, the "Hello World" of notification addons
 
 send_notification() {
+  Updates=("$@")
+  UpdToString=$( printf "%s\n" "${Updates[@]}" )
+  FromHost=$(hostname)
 
-FromHost=$(hostname)
-
-# platform specific notification code would go here
-printf "\n%bGeneric notification addon:%b" "$c_green" "$c_reset"
-printf "\nThe following docker packages on $FromHost need to be updated:\n$@\n"
-
+  # platform specific notification code would go here
+  printf "\n%bGeneric notification addon:%b" "$c_green" "$c_reset"
+  printf "\nThe following docker packages on %s need to be updated:\n%s\n" "$FromHost" "$UpdToString"
 }

--- a/notify_generic.sh
+++ b/notify_generic.sh
@@ -1,0 +1,12 @@
+# copy/rename this file to notify.sh to enable email/text notifications
+# generic sample, the "Hello World" of notification addons
+
+send_notification() {
+
+FromHost=$(hostname)
+
+# platform specific notification code would go here
+printf "\n%bGeneric notification addon:%b" "$c_green" "$c_reset"
+printf "\nThe following docker packages on $FromHost need to be updated:\n$@\n"
+
+}

--- a/notify_generic.sh
+++ b/notify_generic.sh
@@ -9,5 +9,5 @@ send_notification() {
 
   # platform specific notification code would go here
   printf "\n%bGeneric notification addon:%b" "$c_green" "$c_reset"
-  printf "\nThe following docker packages on %s need to be updated:\n%s\n" "$FromHost" "$UpdToString"
+  printf "\nThe following docker containers on %s need to be updated:\n%s\n" "$FromHost" "$UpdToString"
 }

--- a/notify_generic.sh
+++ b/notify_generic.sh
@@ -1,4 +1,5 @@
-# copy/rename this file to notify.sh to enable email/text notifications
+### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
+# Copy/rename this file to notify.sh to enable email/text notifications
 # generic sample, the "Hello World" of notification addons
 
 send_notification() {


### PR DESCRIPTION
This is a followup on Issue #43.

Only two lines are changed in the dockcheck.sh script that run a notification addon if one is present in notify.sh.

notify_generic.sh
A generic "hello world" notification addon. If someone wants to create a notification addon for another platform this is a starting point.

notify_DSM.sh
This is a working notification addon for synology DSM. The _SendMailTo_ variable should be set to the user's own email address. The file must be copied/renamed to notify.sh in order to run. A symbolic link does the trick also.

The dockcheck.sh script's update from git feature could work for addon users since notify.sh is not distributed. A "WARNING: Thirdparty addon use at your own risk" could be added to this and future addons. Now updates are a pain.