### PR TITLE
Update HTTP method in notify_matrix.sh

### DIFF
--- a/notify_matrix.sh
+++ b/notify_matrix.sh
@@ -23,6 +23,6 @@ send_notification() {
 
     # URL Example:  https://matrix.org/_matrix/client/r0/rooms/!xxxxxx:example.com/send/m.room.message?access_token=xxxxxxxx
 
-    curl -sS -o /dev/null --fail -X PUT "$MatrixServer/_matrix/client/r0/rooms/$Room_id/send/m.room.message?access_token=$AccessToken" -H 'Content-Type: application/json' -d "$MsgBody"
+    curl -sS -o /dev/null --fail -X POST "$MatrixServer/_matrix/client/r0/rooms/$Room_id/send/m.room.message?access_token=$AccessToken" -H 'Content-Type: application/json' -d "$MsgBody"
     
 }


### PR DESCRIPTION
Change the HTTP method to POST because, in recent versions, the Synapse server only allows POST for this path.