### PR TITLE
zero configuration DSM notification emails

### DIFF
--- a/notify_DSM.sh
+++ b/notify_DSM.sh
@@ -1,26 +1,33 @@
 ### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
 #
 # Copy/rename this file to notify.sh to enable email notifications on Synology DSM
-# DSM Notification Email has to be configured manually.
+# The existing DSM Notification Email configuration will be used automatically.
 # Modify to your liking - changing SendMailTo and Subject and content.
 
 send_notification() {
 Updates=("$@")
 UpdToString=$( printf "%s\n" "${Updates[@]}" )
 FromHost=$(hostname)
+CfgFile="/usr/syno/etc/synosmtp.conf"
 
 # User variables:
-# change this to your usual destination for synology DSM notification emails
-SendMailTo="me@mydomain.com"
-SubjectTag="diskstation"
+# Automatically sends to your usual destination for synology DSM notification emails.
+# You can also manually override by assigning something else to SendMailTo below.
+SendMailTo=$(grep 'eventmail1' $CfgFile | sed -n 's/.*"\([^"]*\)".*/\1/p')
+#SendMailTo="me@mydomain.com"
+
+SubjectTag=$(grep 'eventsubjectprefix' $CfgFile | sed -n 's/.*"\([^"]*\)".*/\1/p')
+SenderName=$(grep 'smtp_from_name' $CfgFile | sed -n 's/.*"\([^"]*\)".*/\1/p')
+SenderMail=$(grep 'smtp_from_mail' $CfgFile | sed -n 's/.*"\([^"]*\)".*/\1/p')
+SenderMail=${SenderMail:-$(grep 'eventmail1' $CfgFile | sed -n 's/.*"\([^"]*\)".*/\1/p')}
 
 printf "\nSending email notification.\n"
 
 ssmtp $SendMailTo << __EOF
-From: "$FromHost" <$SendMailTo>
+From: "$SenderName" <$SenderMail>
 date:$(date -R)
 To: <$SendMailTo>
-Subject: [$SubjectTag] Updates available on $FromHost
+Subject: $SubjectTag Updates available on $FromHost
 Content-Type: text/plain; charset=UTF-8; format=flowed
 Content-Transfer-Encoding: 7bit
 
@@ -28,7 +35,6 @@ The following containers on $FromHost have updates available:
 
 $UpdToString
 
- From $FromHost
-
+ From $SenderName
 __EOF
 }


### PR DESCRIPTION
Update the DSM notification template to directly use the existing synology DSM configuration. Manual editing of the DSM template is no longer required.

Shamelessly copied from the Tailscale update notifications script on SynoForum.