### PR TITLE
jq rewrite and formatting fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@
 <h3 align="center">CLI tool to automate docker image updates. <br>No <b>pre-pull</b>, selective, optional notifications and prune when done.</h3>
 <h2 align="center">Now with simple notification integrations!</h2>
 <h4 align="center">With features like excluding specific containers, custom container labels, auto-prune when done and more.</h4>
-
+<h4 align="center">Also see the fresh Podman fork <a href="https://github.com/sudo-kraken/podcheck">sudo-kraken/podcheck</a>!</h4>
 ___
 ## :bell: Changelog
 
+- **v0.5.1**: Formatting and efficiency changes feeding back from the fork [sudo-kraken/podcheck](https://github.com/sudo-kraken/podcheck)
 - **v0.5.0**: Rewritten notify logic - all templates are adjusted and should be migrated!
     - Copy the custom settings from your current template to the new version of the same template.
     - Look into, copy and customize the `urls.list` file if that's of interest.
@@ -27,8 +28,6 @@ ___
 - **v0.4.8**: Rewrote prune logic to not prompt with options `-a|-y` or `-n`. Auto prune with `-p`.
 - **v0.4.7**: Notification Template changes to gotify(new!), DSM(improved), SMTP(deprecation alternative).
 - **v0.4.6**: Compatibility changes to timeout, due to busybox.
-- **v0.4.5**: Bugfixes, compatibility changes to timeout and arrays.
-- **v0.4.3**: Added timeout option to skip container if registry check takes too long (10s default).
 ___
 
 
@@ -74,7 +73,7 @@ Containers with updates available:
 Choose what containers to update:
 Enter number(s) separated by comma, [a] for all - [q] to quit:
 ```
-Then it proceedes to run `pull` and `up -d` on every container with updates.  
+Then it proceeds to run `pull` and `up -d` on every container with updates.  
 After the updates are complete, you'll get prompted if you'd like to prune dangling images.
 
 ___

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ___
 ## :bell: Changelog
 
-- **v0.5.1**: Formatting and efficiency changes feeding back from the fork [sudo-kraken/podcheck](https://github.com/sudo-kraken/podcheck)
+- **v0.5.1**: DEPENDENCY WARNING: now requires **jq**. + Upstreaming changes from [sudo-kraken/podcheck](https://github.com/sudo-kraken/podcheck)
 - **v0.5.0**: Rewritten notify logic - all templates are adjusted and should be migrated!
     - Copy the custom settings from your current template to the new version of the same template.
     - Look into, copy and customize the `urls.list` file if that's of interest.

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-VERSION="v0.5.0"
-# ChangeNotes: Rewritten notify logic - all templates adjusted, transfer your current settings to a new template! See README.
+VERSION="v0.5.1"
+# ChangeNotes: DEPENDENCY WARNING: now requires jq. And upstreaming changes from sudo-kraken/podcheck
 Github="https://github.com/mag37/dockcheck"
 RawUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/dockcheck.sh"
 

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 VERSION="v0.5.0"
-### ChangeNotes: Rewritten notify logic - all templates adjusted, transfer your current settings to a new template! See README.
+# ChangeNotes: Rewritten notify logic - all templates adjusted, transfer your current settings to a new template! See README.
 Github="https://github.com/mag37/dockcheck"
 RawUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/dockcheck.sh"
 
-### Variables for self updating
+# Variables for self updating
 ScriptArgs=( "$@" )
 ScriptPath="$(readlink -f "$0")"
 ScriptWorkDir="$(dirname "$ScriptPath")"
 
-### Check if there's a new release of the script:
+# Check if there's a new release of the script
 LatestRelease="$(curl -s -r 0-50 $RawUrl | sed -n "/VERSION/s/VERSION=//p" | tr -d '"')"
-LatestChanges="$(curl -s -r 0-200 $RawUrl | sed -n "/ChangeNotes/s/### ChangeNotes: //p")"
+LatestChanges="$(curl -s -r 0-200 $RawUrl | sed -n "/ChangeNotes/s/# ChangeNotes: //p")"
 
-### Help Function:
+# Help Function
 Help() {
   echo "Syntax:     dockcheck.sh [OPTION] [part of name to filter]"
   echo "Example:    dockcheck.sh -y -d 10 -e nextcloud,heimdall"
@@ -27,9 +27,9 @@ Help() {
   echo "-i     Inform - send a preconfigured notification."
   echo "-l     Only update if label is set. See readme."
   echo "-m     Monochrome mode, no printf color codes."
-  echo "-n     No updates, only checking availability."
-  echo "-p     Auto-Prune dangling images after update."
-  echo "-r     Allow updating images for docker run, wont update the container."
+  echo "-n     No updates; only checking availability."
+  echo "-p     Auto-prune dangling images after update."
+  echo "-r     Allow updating images for docker run; won't update the container."
   echo "-s     Include stopped containers in the check. (Logic: docker ps -a)."
   echo "-t     Set a timeout (in seconds) per container for registry checkups, 10 is default."
   echo "-v     Prints current version."
@@ -37,7 +37,7 @@ Help() {
   echo "Project source: $Github"
 }
 
-### Colors:
+# Colors
 c_red="\033[0;31m"
 c_green="\033[0;32m"
 c_yellow="\033[0;33m"
@@ -68,18 +68,19 @@ while getopts "aynpfrhlisvme:d:t:" options; do
 done
 shift "$((OPTIND-1))"
 
+# Self-update function
 self_update_curl() {
   cp "$ScriptPath" "$ScriptPath".bak
-  if [[ $(builtin type -P curl) ]]; then
+  if [[ $(command -v curl) ]]; then
     curl -L $RawUrl > "$ScriptPath" ; chmod +x "$ScriptPath"
     printf "\n%s\n" "--- starting over with the updated version ---"
     exec "$ScriptPath" "${ScriptArgs[@]}" # run the new script with old arguments
-    exit 1 # exit the old instance
-  elif [[ $(builtin type -P wget) ]]; then
+    exit 1 # Exit the old instance
+  elif [[ $(command -v wget) ]]; then
     wget $RawUrl -O "$ScriptPath" ; chmod +x "$ScriptPath"
     printf "\n%s\n" "--- starting over with the updated version ---"
     exec "$ScriptPath" "${ScriptArgs[@]}" # run the new script with old arguments
-    exit 1 # exit the old instance
+    exit 1 # Exit the old instance
   else
     printf "curl/wget not available - download the update manually: %s \n" "$Github"
   fi
@@ -87,7 +88,7 @@ self_update_curl() {
 
 self_update() {
   cd "$ScriptWorkDir" || { printf "Path error, skipping update.\n" ; return ; }
-  if [[ $(builtin type -P git) ]] && [[ "$(git ls-remote --get-url 2>/dev/null)" =~ .*"mag37/dockcheck".* ]] ; then
+  if [[ $(command -v git) ]] && [[ "$(git ls-remote --get-url 2>/dev/null)" =~ .*"mag37/dockcheck".* ]] ; then
     printf "\n%s\n" "Pulling the latest version."
     git pull --force || { printf "Git error, manually pull/clone.\n" ; return ; }
     printf "\n%s\n" "--- starting over with the updated version ---"
@@ -100,7 +101,7 @@ self_update() {
   fi
 }
 
-### Choose from list -function:
+# Choose from list function
 choosecontainers() {
   while [[ -z "$ChoiceClean" ]]; do
     read -r -p "Enter number(s) separated by comma, [a] for all - [q] to quit: " Choice
@@ -112,7 +113,7 @@ choosecontainers() {
     else
       ChoiceClean=${Choice//[,.:;]/ }
       for CC in $ChoiceClean ; do
-        if [[ "$CC" -lt 1 || "$CC" -gt $UpdCount ]] ; then # reset choice if out of bounds
+        if [[ "$CC" -lt 1 || "$CC" -gt $UpdCount ]] ; then # Reset choice if out of bounds
           echo "Number not in list: $CC" ; unset ChoiceClean ; break 1
         else
           SelectedUpdates+=( "${GotUpdates[$CC-1]}" )
@@ -139,15 +140,15 @@ progress_bar() {
   QueCurrent="$1"
   QueTotal="$2"
   ((Percent=100*QueCurrent/QueTotal))
-  ((Complete=50*Percent/100)) # change first number for width (50)
-  ((Left=50-Complete)) # change first number for width (50)
+  ((Complete=50*Percent/100)) # Change first number for width (50)
+  ((Left=50-Complete)) # Change first number for width (50)
   BarComplete=$(printf "%${Complete}s" | tr " " "#")
   BarLeft=$(printf "%${Left}s" | tr " " "-")
   [[ "$QueTotal" == "$QueCurrent" ]] || printf "\r[%s%s] %s/%s " "$BarComplete" "$BarLeft" "$QueCurrent" "$QueTotal"
   [[ "$QueTotal" == "$QueCurrent" ]] && printf "\r[%b%s%b] %s/%s \n" "$c_teal" "$BarComplete" "$c_reset" "$QueCurrent" "$QueTotal"
 }
 
-### Function to add user-provided urls to releasenotes
+# Function to add user-provided urls to releasenotes
 releasenotes() { 
   for update in ${GotUpdates[@]}; do
     found=false
@@ -158,7 +159,7 @@ releasenotes() {
   done
 }
 
-### Version check & initiate self update
+# Version check & initiate self update
 if [[ "$VERSION" != "$LatestRelease" ]] ; then
   printf "New version available! %b%s%b ⇒ %b%s%b \n Change Notes: %s \n" "$c_yellow" "$VERSION" "$c_reset" "$c_green" "$LatestRelease" "$c_reset" "$LatestChanges"
   if [[ -z "$AutoUp" ]] ; then
@@ -167,26 +168,26 @@ if [[ "$VERSION" != "$LatestRelease" ]] ; then
   fi
 fi
 
-### Set $1 to a variable for name filtering later.
+# Set $1 to a variable for name filtering later
 SearchName="$1"
-### Create array of excludes
+# Create array of excludes
 IFS=',' read -r -a Excludes <<< "$Exclude" ; unset IFS
 
-### Check if required binary exists in PATH or directory:
-if [[ $(builtin type -P "regctl") ]]; then regbin="regctl" ;
+# Check if required binary exists in PATH or directory
+if [[ $(command -v "regctl") ]]; then regbin="regctl" ;
 elif [[ -f "$ScriptWorkDir/regctl" ]]; then regbin="$ScriptWorkDir/regctl" ;
 else
   read -r -p "Required dependency 'regctl' missing, do you want it downloaded? y/[n] " GetDep
   if [[ "$GetDep" =~ [yY] ]] ; then
-    ### Check arch:
+    # Check architecture
     case "$(uname --machine)" in
       x86_64|amd64) architecture="amd64" ;;
       arm64|aarch64) architecture="arm64";;
       *) echo "Architecture not supported, exiting." ; exit 1;;
     esac
     RegUrl="https://github.com/regclient/regclient/releases/latest/download/regctl-linux-$architecture"
-    if [[ $(builtin type -P curl) ]]; then curl -L $RegUrl > "$ScriptWorkDir/regctl" ; chmod +x "$ScriptWorkDir/regctl" ; regbin="$ScriptWorkDir/regctl" ;
-    elif [[ $(builtin type -P wget) ]]; then wget $RegUrl -O "$ScriptWorkDir/regctl" ; chmod +x "$ScriptWorkDir/regctl" ; regbin="$ScriptWorkDir/regctl" ;
+    if [[ $(command -v curl) ]]; then curl -L $RegUrl > "$ScriptWorkDir/regctl" ; chmod +x "$ScriptWorkDir/regctl" ; regbin="$ScriptWorkDir/regctl" ;
+    elif [[ $(command -v wget) ]]; then wget $RegUrl -O "$ScriptWorkDir/regctl" ; chmod +x "$ScriptWorkDir/regctl" ; regbin="$ScriptWorkDir/regctl" ;
     else
       printf "%s\n" "curl/wget not available - get regctl manually from the repo link, quitting."
     fi
@@ -195,10 +196,10 @@ else
     exit 1
   fi
 fi
-### final check if binary is correct
+# Final check if binary is correct
 $regbin version &> /dev/null  || { printf "%s\n" "regctl is not working - try to remove it and re-download it, exiting."; exit 1; }
 
-### Check docker compose binary:
+# Check docker compose binary
 if docker compose version &> /dev/null ; then DockerBin="docker compose" ;
 elif docker-compose -v &> /dev/null; then DockerBin="docker-compose" ;
 elif docker -v &> /dev/null; then
@@ -209,7 +210,7 @@ else
   exit 1
 fi
 
-### Numbered List -function:
+# Numbered List function
 options() {
 num=1
 for i in "${GotUpdates[@]}"; do
@@ -218,7 +219,7 @@ for i in "${GotUpdates[@]}"; do
 done
 }
 
-### Listing typed exclusions:
+# Listing typed exclusions
 if [[ -n ${Excludes[*]} ]] ; then
   printf "\n%bExcluding these names:%b\n" "$c_blue" "$c_reset"
   printf "%s\n" "${Excludes[@]}"
@@ -229,8 +230,8 @@ fi
 DocCount=$(docker ps $Stopped --filter "name=$SearchName" --format '{{.Names}}' | wc -l)
 RegCheckQue=0
 
-### Testing and setting timeout binary
-t_out=$(type -P "timeout")
+# Testing and setting timeout binary
+t_out=$(command -v "timeout")
 if [[ $t_out ]]; then
   t_out=$(realpath $t_out 2>/dev/null || readlink -f $t_out)
   if [[ $t_out =~ "busybox" ]]; then
@@ -240,15 +241,15 @@ if [[ $t_out ]]; then
 else t_out=""
 fi
 
-### Check the image-hash of every running container VS the registry
+# Check the image-hash of every running container VS the registry
 for i in $(docker ps $Stopped --filter "name=$SearchName" --format '{{.Names}}') ; do
   ((RegCheckQue+=1))
   progress_bar "$RegCheckQue" "$DocCount"
-  ### Looping every item over the list of excluded names and skipping:
+  # Looping every item over the list of excluded names and skipping
   for e in "${Excludes[@]}" ; do [[ "$i" == "$e" ]] && continue 2 ; done
   RepoUrl=$(docker inspect "$i" --format='{{.Config.Image}}')
   LocalHash=$(docker image inspect "$RepoUrl" --format '{{.RepoDigests}}')
-  # Checking for errors while setting the variable:
+  # Checking for errors while setting the variable
   if RegHash=$(${t_out} $regbin -v error image digest --list "$RepoUrl" 2>&1) ; then
     if [[ "$LocalHash" = *"$RegHash"* ]] ; then
       NoUpdates+=("$i")
@@ -260,27 +261,27 @@ for i in $(docker ps $Stopped --filter "name=$SearchName" --format '{{.Names}}')
       fi
     fi
   else
-    # Here the RegHash is the result of an error code.
+    # Here the RegHash is the result of an error code
     GotErrors+=("$i - ${RegHash}")
   fi
 done
 
-### Sort arrays alphabetically
+# Sort arrays alphabetically
 IFS=$'\n'
 NoUpdates=($(sort <<<"${NoUpdates[*]}"))
 GotUpdates=($(sort <<<"${GotUpdates[*]}"))
 unset IFS
 
-### Define how many updates are available
+# Define how many updates are available
 UpdCount="${#GotUpdates[@]}"
 
-### List what containers got updates or not
+# List what containers got updates or not
 if [[ -n ${NoUpdates[*]} ]] ; then
   printf "\n%bContainers on latest version:%b\n" "$c_green" "$c_reset"
   printf "%s\n" "${NoUpdates[@]}"
 fi
 if [[ -n ${GotErrors[*]} ]] ; then
-  printf "\n%bContainers with errors, wont get updated:%b\n" "$c_red" "$c_reset"
+  printf "\n%bContainers with errors, won't get updated:%b\n" "$c_red" "$c_reset"
   printf "%s\n" "${GotErrors[@]}"
   printf "%binfo:%b 'unauthorized' often means not found in a public registry.\n" "$c_blue" "$c_reset"
 fi
@@ -290,11 +291,11 @@ if [[ -n ${GotUpdates[*]} ]] ; then
    [[ -n "$Notify" ]] && { [[ $(type -t send_notification) == function ]] && send_notification "${GotUpdates[@]}" || printf "Could not source notification function.\n" ; }
 fi
 
-### Optionally get updates if there's any
+# Optionally get updates if there's any
 if [ -n "$GotUpdates" ] ; then
   if [ -z "$AutoUp" ] ; then
-  printf "\n%bChoose what containers to update.%b\n" "$c_teal" "$c_reset"
-  choosecontainers
+    printf "\n%bChoose what containers to update.%b\n" "$c_teal" "$c_reset"
+    choosecontainers
   else
     SelectedUpdates=( "${GotUpdates[@]}" )
   fi
@@ -312,7 +313,7 @@ if [ -n "$GotUpdates" ] ; then
       ContImage=$(docker inspect "$i" --format='{{.Config.Image}}')
       ContUpdateLabel=$(docker inspect "$i" --format '{{ index .Config.Labels "mag37.dockcheck.update" }}')
       ContRestartStack=$(docker inspect "$i" --format '{{ index .Config.Labels "mag37.dockcheck.restart-stack" }}')
-      ### Checking if compose-values are empty - hence started with docker run:
+      # Checking if compose-values are empty - hence started with docker run
       if [ -z "$ContPath" ] ; then
         if [ "$DRunUp" == "yes" ] ; then
           docker pull "$ContImage"
@@ -322,7 +323,7 @@ if [ -n "$GotUpdates" ] ; then
         fi
         continue
       fi
-      ### cd to the compose-file directory to account for people who use relative volumes, eg - ${PWD}/data:data
+      # cd to the compose-file directory to account for people who use relative volumes
       cd "$ContPath" || { echo "Path error - skipping $i" ; continue ; }
       ## Reformatting path + multi compose
       if [[ $ContConfigFile = '/'* ]] ; then
@@ -331,12 +332,12 @@ if [ -n "$GotUpdates" ] ; then
         CompleteConfs=$(for conf in ${ContConfigFile//,/ } ; do printf -- "-f %s/%s " "$ContPath" "$conf"; done)
       fi
       printf "\n%bNow updating (%s/%s): %b%s%b\n" "$c_teal" "$CurrentQue" "$NumberofUpdates" "$c_blue" "$i" "$c_reset"
-      ### Checking if Label Only -option is set, and if container got the label
+      # Checking if Label Only -option is set, and if container got the label
       [[ "$OnlyLabel" == true ]] && { [[ "$ContUpdateLabel" != true ]] && { echo "No update label, skipping." ; continue ; } }
       docker pull "$ContImage"
-      ### Check if the container got an environment file set and reformat it
+      # Check if the container got an environment file set and reformat it
       if [ -n "$ContEnv" ]; then ContEnvs=$(for env in ${ContEnv//,/ } ; do printf -- "--env-file %s " "$env"; done) ; fi
-      ### Check if the whole stack should be restarted
+      # Check if the whole stack should be restarted
       if [[ "$ContRestartStack" == true ]] || [[ "$ForceRestartStacks" == true ]] ; then
         $DockerBin ${CompleteConfs} stop ; $DockerBin ${CompleteConfs} ${ContEnvs} up -d
       else

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -233,7 +233,7 @@ if [[ -n ${Excludes[*]} ]] ; then
 fi
 
 # Variables for progress_bar function
-DocCount=$(docker ps $Stopped --filter "name=$SearchName" --format '{{.Names}}' | wc -l)
+ContCount=$(docker ps $Stopped --filter "name=$SearchName" --format '{{.Names}}' | wc -l)
 RegCheckQue=0
 
 # Testing and setting timeout binary
@@ -250,7 +250,7 @@ fi
 # Check the image-hash of every running container VS the registry
 for i in $(docker ps $Stopped --filter "name=$SearchName" --format '{{.Names}}') ; do
   ((RegCheckQue+=1))
-  progress_bar "$RegCheckQue" "$DocCount"
+  progress_bar "$RegCheckQue" "$ContCount"
   # Looping every item over the list of excluded names and skipping
   for e in "${Excludes[@]}" ; do [[ "$i" == "$e" ]] && continue 2 ; done
   RepoUrl=$(docker inspect "$i" --format='{{.Config.Image}}')


### PR DESCRIPTION
Upstreaming some work done in the podcheck-fork. 
- Formatting / syntax changes.
- Converted container metadata extraction to jq to avoid running multiple docker inspects.
- Generalized a variable name to work for both docker and podman.