### PR TITLE
osX + bsd support, dependency installer rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,11 @@
 ___
 ## :bell: Changelog
 
+- **v0.5.5.0**: osx and bsd compatibility changes + rewrite of dependency installer
 - **v0.5.4.0**: Added support for a Prometheus+node_exporter metric collection through a file collector.
 - **v0.5.3.0**: Local image check changed (use imageId instead of name) and Gotify-template fixed (whale icon removed).
 - **v0.5.2.1**: Rewrite of dependency downloads, jq can be installed with package manager or static binary.
 - **v0.5.1**: DEPENDENCY WARNING: now requires **jq**. + Upstreaming changes from [sudo-kraken/podcheck](https://github.com/sudo-kraken/podcheck)
-- **v0.5.0**: Rewritten notify logic - all templates are adjusted and should be migrated!
-    - Copy the custom settings from your current template to the new version of the same template.
-    - Look into, copy and customize the `urls.list` file if that's of interest.
-    - Other changes:
-        - Added Discord notify template.
-        - Verbosity changed of `regctl`.
-- **v0.4.9**: Added a function to enrich the notify-message with release note URLs. See [Release notes addon](https://github.com/mag37/dockcheck#date-release-notes-addon-to-notifications)
 ___
 
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ ___
   - regctl requires `amd64/arm64` - see [workaround](#roller_coaster-workaround-for-non-amd64--arm64) if other architecture is used.
 
 ## :tent: Install Instructions
-Download the script to a directory in **PATH**, I'd suggest using `~/.local/bin` as that's usually in **PATH**.
+Download the script to a directory in **PATH**, I'd suggest using `~/.local/bin` as that's usually in **PATH**.   
+For OSX/macOS preferably use `/usr/local/bin`.
 ```sh
 # basic example with curl:
 curl -L https://raw.githubusercontent.com/mag37/dockcheck/main/dockcheck.sh -o ~/.local/bin/dockcheck.sh
@@ -98,6 +99,9 @@ chmod +x ~/.local/bin/dockcheck.sh
 
 # or oneliner with wget:
 wget -O ~/.local/bin/dockcheck.sh "https://raw.githubusercontent.com/mag37/dockcheck/main/dockcheck.sh" && chmod +x ~/.local/bin/dockcheck.sh
+
+# OSX or macOS version with curl:
+ curl -L https://raw.githubusercontent.com/mag37/dockcheck/main/dockcheck.sh -o /usr/local/bin/dockcheck.sh && chmod +x /usr/local/bin/dockcheck.sh
 ```
 Then call the script anywhere with just `dockcheck.sh`.
 Add preferred `notify.sh`-template to the same directory - this will not be touched by the scripts self-update function.

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -153,7 +153,7 @@ progress_bar() {
 }
 
 # Function to add user-provided urls to releasenotes
-releasenotes() { 
+releasenotes() {
   for update in ${GotUpdates[@]}; do
     found=false
     while read -r container url; do
@@ -187,8 +187,8 @@ binary_downloader() {
     *) printf "\n%bArchitecture not supported, exiting.%b\n" "$c_red" "$c_reset" ; exit 1;;
   esac
   GetUrl="${BinaryUrl/TEMP/"$architecture"}"
-  if [[ $(command -v curl) ]]; then curl -L $GetUrl > "$ScriptWorkDir/$BinaryName" ; 
-  elif [[ $(command -v wget) ]]; then wget $GetUrl -O "$ScriptWorkDir/$BinaryName" ; 
+  if [[ $(command -v curl) ]]; then curl -L $GetUrl > "$ScriptWorkDir/$BinaryName" ;
+  elif [[ $(command -v wget) ]]; then wget $GetUrl -O "$ScriptWorkDir/$BinaryName" ;
   else printf "%s\n" "curl/wget not available - get $BinaryName manually from the repo link, exiting."; exit 1;
   fi
   [[ -f "$ScriptWorkDir/$BinaryName" ]] && chmod +x "$ScriptWorkDir/$BinaryName"
@@ -213,13 +213,13 @@ else
   GetJq=${GetJq:-no} # set default to no if nothing is given
   if [[ "$GetJq" =~ [yYsS] ]] ; then
     [[ "$GetJq" =~ [yY] ]] && distro_checker
-    if [[ -n "$PkgInstaller" && "$PkgInstaller" != "ERROR" ]] ; then 
+    if [[ -n "$PkgInstaller" && "$PkgInstaller" != "ERROR" ]] ; then
       ($PkgInstaller jq) ; PkgExitcode="$?"
       [[ "$PkgExitcode" == 0 ]] && jqbin="jq" || printf "\n%bPackagemanager install failed%b, falling back to static binary.\n" "$c_yellow" "$c_reset"
     fi
     if [[ "$GetJq" =~ [sS] || "$PkgInstaller" == "ERROR" || "$PkgExitcode" != 0 ]] ; then
         binary_downloader "jq" "https://github.com/jqlang/jq/releases/latest/download/jq-linux-TEMP"
-        [[ -f "$ScriptWorkDir/jq" ]] && jqbin="$ScriptWorkDir/jq" 
+        [[ -f "$ScriptWorkDir/jq" ]] && jqbin="$ScriptWorkDir/jq"
     fi
   else printf "\n%bDependency missing, exiting.%b\n" "$c_red" "$c_reset" ; exit 1 ;
   fi
@@ -233,19 +233,19 @@ elif [[ -f "$ScriptWorkDir/regctl" ]]; then regbin="$ScriptWorkDir/regctl" ;
 else
   read -r -p "Required dependency 'regctl' missing, do you want it downloaded? y/[n] " GetRegctl
   if [[ "$GetRegctl" =~ [yY] ]] ; then
-    if [[ $(uname -s) == "Darwin" ]]; then 
+    if [[ $(uname -s) == "Darwin" ]]; then
       echo "Detected macOS, Installing regclient using Homebrew."
       distro_checker
-      if [[ -n "$PkgInstaller" && "$PkgInstaller" != "ERROR" ]] ; then 
+      if [[ -n "$PkgInstaller" && "$PkgInstaller" != "ERROR" ]] ; then
         ($PkgInstaller regclient) ; PkgExitcode="$?"
         [[ "$PkgExitcode" == 0 ]] && regbin="regclient" || printf "\n%bPackagemanager install failed%b, falling back to static binary.\n" "$c_yellow" "$c_reset"
       fi
     else
       GetRegctl="S"
     fi
-    if [[ "$GetRegct" =~ [Ss] || "$PkgInstaller" == "ERROR" || "$PkgExitcode" != 0 ]] ; then
+    if [[ "$GetRegctl" =~ [Ss] || "$PkgInstaller" == "ERROR" || "$PkgExitcode" != 0 ]] ; then
       binary_downloader "regctl" "https://github.com/regclient/regclient/releases/latest/download/regctl-linux-TEMP"
-      [[ -f "$ScriptWorkDir/regctl" ]] && regbin="$ScriptWorkDir/regctl" 
+      [[ -f "$ScriptWorkDir/regctl" ]] && regbin="$ScriptWorkDir/regctl"
     fi
   else printf "\n%bDependency missing, exiting.%b\n" "$c_red" "$c_reset" ; exit 1 ;
   fi

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -219,7 +219,7 @@ dependency_check() {
       [[ "$GetBin" =~ [yY] ]] && distro_checker
       if [[ -n "$PkgInstaller" && "$PkgInstaller" != "ERROR" ]] ; then
         [[ $(uname -s) == "Darwin" && "$AppName" == "regctl" ]] && AppName="regclient"
-        ($PkgInstaller $AppName) ; PkgExitcode="$?"
+        ($PkgInstaller $AppName) ; PkgExitcode="$?" && AppName="$1"
         if [[ "$PkgExitcode" == 0 ]] ; then { export $AppVar="$AppName" && printf "\n%b$AppName installed.%b\n" "$c_green" "$c_reset"; }
         else printf "\n%bPackagemanager install failed%b, falling back to static binary.\n" "$c_yellow" "$c_reset"
         fi

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -221,7 +221,7 @@ dependency_check() {
         [[ $(uname -s) == "Darwin" && "$AppName" == "regctl" ]] && AppName=regclient
         ($PkgInstaller $AppName) ; PkgExitcode="$?"
         if [[ "$PkgExitcode" == 0 ]] ; then { export $AppVar="$AppName" && printf "\n%b$AppName installed.%b\n" "$c_green" "$c_reset"; }
-    else printf "\n%bPackagemanager install failed%b, falling back to static binary.\n" "$c_yellow" "$c_reset"
+        else printf "\n%bPackagemanager install failed%b, falling back to static binary.\n" "$c_yellow" "$c_reset"
         fi
       fi
       if [[ "$GetBin" =~ [sS] || "$PkgInstaller" == "ERROR" || "$PkgExitcode" != 0 ]] ; then

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -316,7 +316,7 @@ unset IFS
 
 # Run the prometheus exporter function
 if [ -n "$CollectorTextFileDirectory" ] ; then
-  source "$ScriptWorkDir"/addons/prometheus/prometheus_collector.sh && prometheus_exporter ${#NoUpdates[@]} ${#GotUpdates[@]} ${#GotError[@]}
+  source "$ScriptWorkDir"/addons/prometheus/prometheus_collector.sh && prometheus_exporter ${#NoUpdates[@]} ${#GotUpdates[@]} ${#GotErrors[@]}
 fi
 
 # Define how many updates are available

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -131,7 +131,8 @@ choosecontainers() {
 
 datecheck() {
   ImageDate=$($regbin -v error image inspect "$RepoUrl" --format='{{.Created}}' | cut -d" " -f1 )
-  ImageAge=$(( ( $(date +%s) - $(date -d "$ImageDate" +%s) )/86400 ))
+  ImageEpoch=$(date -d "$ImageDate" +%s 2>/dev/null) || ImageEpoch=$(date -f "%Y-%m-%d" -j "$ImageDate" +%s)
+  ImageAge=$(( ( $(date +%s) - $ImageEpoch )/86400 ))
   if [ "$ImageAge" -gt "$DaysOld" ] ; then
     return 0
   else
@@ -180,7 +181,7 @@ IFS=',' read -r -a Excludes <<< "$Exclude" ; unset IFS
 binary_downloader() {
   BinaryName="$1"
   BinaryUrl="$2"
-  case "$(uname --machine)" in
+  case "$(uname -m)" in
     x86_64|amd64) architecture="amd64" ;;
     arm64|aarch64) architecture="arm64";;
     *) printf "\n%bArchitecture not supported, exiting.%b\n" "$c_red" "$c_reset" ; exit 1;;

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -206,35 +206,35 @@ distro_checker() {
 
 # Dependency check + installer function
 dependency_check() {
- AppName="$1"
- AppVar="$2"
- AppUrl="$3"
- if [[ $(command -v $AppName) ]]; then export $AppVar="$AppName" ;
- elif [[ -f "$ScriptWorkDir/$AppName" ]]; then export $AppVar="$ScriptWorkDir/$AppName" ;
- else
-   printf "%s\n" "Required dependency '$AppName' missing, do you want to install it?"
-   read -r -p "y: With packagemanager (sudo). / s: Download static binary. y/s/[n] " GetBin
-   GetBin=${GetBin:-no} # set default to no if nothing is given
-   if [[ "$GetBin" =~ [yYsS] ]] ; then
-     [[ "$GetBin" =~ [yY] ]] && distro_checker
-     if [[ -n "$PkgInstaller" && "$PkgInstaller" != "ERROR" ]] ; then
-       [[ $(uname -s) == "Darwin" && "$AppName" == "regctl" ]] && AppName=regclient
-       ($PkgInstaller $AppName) ; PkgExitcode="$?"
-       if [[ "$PkgExitcode" == 0 ]] ; then { export $AppVar="$AppName" && printf "\n%b$AppName installed.%b\n" "$c_green" "$c_reset"; }  
-   else printf "\n%bPackagemanager install failed%b, falling back to static binary.\n" "$c_yellow" "$c_reset"
-       fi
-     fi
-     if [[ "$GetBin" =~ [sS] || "$PkgInstaller" == "ERROR" || "$PkgExitcode" != 0 ]] ; then
-         binary_downloader "$AppName" "$AppUrl"
-         [[ -f "$ScriptWorkDir/$AppName" ]] && { export $AppVar="$ScriptWorkDir/$1" && printf "\n%b$AppName downloaded.%b\n" "$c_green" "$c_reset"; }
-     fi
-   else printf "\n%bDependency missing, exiting.%b\n" "$c_red" "$c_reset" ; exit 1 ;
-   fi
- fi
- # Final check if binary is correct
- [[ "$1" == "jq" ]] && VerFlag="--version"
- [[ "$1" == "regctl" ]] && VerFlag="version"
- ${!AppVar} $VerFlag &> /dev/null  || { printf "%s\n" "$AppName is not working - try to remove it and re-download it, exiting."; exit 1; }
+  AppName="$1"
+  AppVar="$2"
+  AppUrl="$3"
+  if [[ $(command -v $AppName) ]]; then export $AppVar="$AppName" ;
+  elif [[ -f "$ScriptWorkDir/$AppName" ]]; then export $AppVar="$ScriptWorkDir/$AppName" ;
+  else
+    printf "%s\n" "Required dependency '$AppName' missing, do you want to install it?"
+    read -r -p "y: With packagemanager (sudo). / s: Download static binary. y/s/[n] " GetBin
+    GetBin=${GetBin:-no} # set default to no if nothing is given
+    if [[ "$GetBin" =~ [yYsS] ]] ; then
+      [[ "$GetBin" =~ [yY] ]] && distro_checker
+      if [[ -n "$PkgInstaller" && "$PkgInstaller" != "ERROR" ]] ; then
+        [[ $(uname -s) == "Darwin" && "$AppName" == "regctl" ]] && AppName=regclient
+        ($PkgInstaller $AppName) ; PkgExitcode="$?"
+        if [[ "$PkgExitcode" == 0 ]] ; then { export $AppVar="$AppName" && printf "\n%b$AppName installed.%b\n" "$c_green" "$c_reset"; }
+    else printf "\n%bPackagemanager install failed%b, falling back to static binary.\n" "$c_yellow" "$c_reset"
+        fi
+      fi
+      if [[ "$GetBin" =~ [sS] || "$PkgInstaller" == "ERROR" || "$PkgExitcode" != 0 ]] ; then
+          binary_downloader "$AppName" "$AppUrl"
+          [[ -f "$ScriptWorkDir/$AppName" ]] && { export $AppVar="$ScriptWorkDir/$1" && printf "\n%b$AppName downloaded.%b\n" "$c_green" "$c_reset"; }
+      fi
+    else printf "\n%bDependency missing, exiting.%b\n" "$c_red" "$c_reset" ; exit 1 ;
+    fi
+  fi
+  # Final check if binary is correct
+  [[ "$1" == "jq" ]] && VerFlag="--version"
+  [[ "$1" == "regctl" ]] && VerFlag="version"
+  ${!AppVar} $VerFlag &> /dev/null  || { printf "%s\n" "$AppName is not working - try to remove it and re-download it, exiting."; exit 1; }
 }
 
 dependency_check "regctl" "regbin" "https://github.com/regclient/regclient/releases/latest/download/regctl-linux-TEMP"

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-VERSION="v0.5.4.0"
-### ChangeNotes: Added support for a Prometheus+node_exporter metric collection through a file collector.
+VERSION="v0.5.5.0"
+### ChangeNotes: osx and bsd compatibility changes + rewrite of dependency installer
 Github="https://github.com/mag37/dockcheck"
 RawUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/dockcheck.sh"
 

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -242,9 +242,11 @@ else
       fi
     else
       GetRegctl="S"
+    fi
     if [[ "$GetRegct" =~ [Ss] || "$PkgInstaller" == "ERROR" || "$PkgExitcode" != 0 ]] ; then
       binary_downloader "regctl" "https://github.com/regclient/regclient/releases/latest/download/regctl-linux-TEMP"
       [[ -f "$ScriptWorkDir/regctl" ]] && regbin="$ScriptWorkDir/regctl" 
+    fi
   else printf "\n%bDependency missing, exiting.%b\n" "$c_red" "$c_reset" ; exit 1 ;
   fi
 fi

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -218,7 +218,7 @@ dependency_check() {
     if [[ "$GetBin" =~ [yYsS] ]] ; then
       [[ "$GetBin" =~ [yY] ]] && distro_checker
       if [[ -n "$PkgInstaller" && "$PkgInstaller" != "ERROR" ]] ; then
-        [[ $(uname -s) == "Darwin" && "$AppName" == "regctl" ]] && AppName=regclient
+        [[ $(uname -s) == "Darwin" && "$AppName" == "regctl" ]] && AppName="regclient"
         ($PkgInstaller $AppName) ; PkgExitcode="$?"
         if [[ "$PkgExitcode" == 0 ]] ; then { export $AppVar="$AppName" && printf "\n%b$AppName installed.%b\n" "$c_green" "$c_reset"; }
         else printf "\n%bPackagemanager install failed%b, falling back to static binary.\n" "$c_yellow" "$c_reset"


### PR DESCRIPTION
Some osx / bsd compatibility changes.
Rewritten the dependency (jq + regctl) install method.
Many thanks to @pshannon-git for testing!