### PR TITLE
use notification release notes url function for cli options as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ Use a `notify_X.sh` template file from the **notify_templates** directory, copy 
 Further additions are welcome - suggestions or PR!  
 <sub><sup>Initiated and first contributed by [yoyoma2](https://github.com/yoyoma2).</sup></sub>  
 
-### :date: Release notes addon to Notifications
-There's a function to use a lookup-file to add release note URL's to the notification message.  
+### :date: Release notes addon
+There's a function to use a lookup-file to add release note URL's to the notification message and the cli updated container options.  
 Copy the notify_templates/`urls.list` file to the script directory, it will be used automatically if it's there.   Modify it as necessary, the names of interest in the left column needs to match your container names.  
 The output of the notification will look something like this:
 ```

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -292,13 +292,15 @@ dependency_check() {
 }
 
 # Numbered List function
+# if urls.list exists add release note url per line
 options() {
   num=1
-  for i in "${GotUpdates[@]}"; do
-    echo "$num) $i"
+  [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("${GotUpdates[@]}")
+  for update in "${Updates[@]}"; do
+    echo "$num) $update"
     ((num++))
   done
-  }
+}
 
 # Version check & initiate self update
 if [[ "$VERSION" != "$LatestRelease" ]]; then


### PR DESCRIPTION
The feature for adding update release note urls per container is great for quick access.

This pr adds the release notes to each line in the updatable container options when the cli is used.

Why?

If you use iTerm, for example, you can then navigate directly to the release notes by CMD+clicking on the URL. This helps a lot to decide which container should receive an update and which should wait.