### PR TITLE
Style and additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@
 <h2 align="center">CLI tool to automate docker image updates or notifying when updates are available.</h2>
 <h3 align="center">selective updates, exclude containers, custom labels, notification plugins, prune when done etc.</h3>
 
-<h4 align="center">For Podman - see the fork <a href="https://github.com/sudo-kraken/podcheck">sudo-kraken/podcheck</a>!</h4>
-
 <h4 align="center">:whale: Docker Hub pull limit :chart_with_downwards_trend: not an issue for checks but for actual pulls - <a href="#whale-docker-hub-pull-limit-chart_with_downwards_trend-not-an-issue-for-checks-but-for-actual-pulls">read more</a></h4>
+
+<h5 align="center">For Podman - see the fork <a href="https://github.com/sudo-kraken/podcheck">sudo-kraken/podcheck</a>!</h4>
 
 ___
 ## :bell: Changelog
 
 - **v0.6.2**: Style and colour changes, prometheus hotfix, new options:
     - `-u`, Allow auto self update of dockcheck.sh
-    - `-I`, Print container release URLs in the CLI "choose update" list.
+    - `-I`, Print container release URLs in the CLI "choose update" list. (please contribute to `urls.list`)
     - Extras: `-m`, Monochrome mode now hides the progress bar.
 - **v0.6.1**: Hotfixes: (try removing set+shopt+shopt if debugging more errors)
     - xargs/pipefail, removed `-set -e` bash option for now.
@@ -32,14 +32,7 @@ ___
     - Safer bash options with `set -euo pipefail`, `shopt -s nullglob` and `failglob`.
     - Added a `default.conf` for user settings - persistent through updates.
     - Added `notify_slack.sh` template for slack curl api.
-- **v0.5.8**: Added version checks to all templates and a notification if a new template is released.
-- **v0.5.7**: Rewritten templates - now with a function to notify when there's a new Dockcheck release.
-    - Manually migrate your current `notify.sh` settings to a new template for new functionality.
-- **v0.5.6.1**: Async xargs hotfix - due to errors `failed to request manifest head ... context canceled`
-    - Defaulted subprocess to 1 with `MaxAsync=1`, increase to find a stable value in your environment.
-    - Added `-x N` option to pass `MaxAsync` value at runtime.
-    - To disable xargs `-P` flag (max processes) all together, set `MaxAsync` to 0.
-- **v0.5.6.0**: Heavily improved performance due to async checking for updates.
+
 ___
 
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@
 ___
 ## :bell: Changelog
 
+- **v0.6.2**: Style and colour changes, prometheus hotfix, new options:
+    - `-u`, Allow auto self update of dockcheck.sh
+    - `-I`, Print container release URLs in the CLI "choose update" list.
+    - Extras: `-m`, Monochrome mode now hides the progress bar.
 - **v0.6.1**: Hotfixes: (try removing set+shopt+shopt if debugging more errors)
     - xargs/pipefail, removed `-set -e` bash option for now.
     - unbound variables fixed (hopefully)
@@ -55,13 +59,15 @@ Options:
 -f     Force stack restart after update. Caution: restarts once for every updated container within stack.
 -h     Print this Help.
 -i     Inform - send a preconfigured notification.
+-I     Prints custom releasenote urls alongside each container with updates (requires urls.list).
 -l     Only update if label is set. See readme.
--m     Monochrome mode, no printf color codes.
+-m     Monochrome mode, no printf colour codes and hides progress bar.
 -n     No updates, only checking availability.
 -p     Auto-Prune dangling images after update.
 -r     Allow updating images for docker run, wont update the container.
 -s     Include stopped containers in the check. (Logic: docker ps -a).
 -t N   Set a timeout (in seconds) per container for registry checkups, 10 is default.
+-u     Allow automatic self updates - caution as this will pull new code and autorun it.
 -v     Prints current version.
 -x N   Set max asynchronous subprocesses, 1 default, 0 to disable, 32+ tested.
 ```

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@
 </p>
 
 <h2 align="center">CLI tool to automate docker image updates or notifying when updates are available.</h2>
-<h3 align="center">Features:</h3>
-<h3 align="center">selective updates, exclude containers, custom labels, notification plugins, prune when done and more.</h3>
+<h3 align="center">selective updates, exclude containers, custom labels, notification plugins, prune when done etc.</h3>
 
 <h4 align="center">For Podman - see the fork <a href="https://github.com/sudo-kraken/podcheck">sudo-kraken/podcheck</a>!</h4>
 
@@ -121,9 +120,9 @@ Alternatively create an alias where specific flags and values are set.
 Example `alias dc=dockcheck.sh -p -x 10 -t 3`.
 
 ## :loudspeaker: Notifications
-Trigger with the `-i` flag.  
+Trigger with the `-i` flag if `notify.sh` is present and configured.  
+Will send a list of containers with updates available and a notification when `dockcheck.sh` itself has an update.  
 Run it scheduled with `-ni` to only get notified when there's updates available!  
-Will also send a notification when `dockcheck.sh` itself has an update.
 
 Use a `notify_X.sh` template file from the **notify_templates** directory, copy it to `notify.sh` alongside the script, modify it to your needs! (notify.sh is added to .gitignore)  
 **Current templates:**
@@ -162,16 +161,30 @@ Pass `-x N` where N is number of subprocesses allowed, experiment in your enviro
 Change the default value by editing the `MaxAsync=N` variable in `dockcheck.sh`. To disable the subprocess function set `MaxAsync=0`.
 
 
-## :chart_with_upwards_trend: Prometheus and node_exporter
+## :chart_with_upwards_trend: Extra plugins and tools:
+
+### :small_orange_diamond: Prometheus and node_exporter
 Dockcheck can be used together with [Prometheus](https://github.com/prometheus/prometheus) and [node_exporter](https://github.com/prometheus/node_exporter) to export metrics via the file collector, scheduled with cron or likely.
 This is done with the `-c` option, like this:
 ```
 dockcheck.sh -c /path/to/exporter/directory
 ```
 
-See the [README.md](./addons/prometheus/README.md) for more detailed information on how to set it up!
-
+See the [README.md](./addons/prometheus/README.md) for more detailed information on how to set it up!  
 <sub><sup>Contributed by [tdralle](https://github.com/tdralle).</sup></sub>  
+
+### :small_orange_diamond: Zabbix config to monitor docker image updates
+If you already use Zabbix - this config will Shows number of available docker image updates on host.   
+Example: *2 Docker Image updates on host-xyz*  
+See project: [thetorminal/zabbix-docker-image-updates](https://github.com/thetorminal/zabbix-docker-image-updates)
+
+### :small_orange_diamond: Serve REST API to list all available updates
+A custom python script to serve a REST API to get pulled into other monitoring tools like [homepage](https://github.com/gethomepage/homepage).  
+See [discussion here](https://github.com/mag37/dockcheck/discussions/146).
+
+### :small_orange_diamond: Wrapper Script for Unraid's User Scripts
+A custom bash wrapper script to allow the usage of dockcheck as a Unraid User Script plugin.  
+See [discussion here](https://github.com/mag37/dockcheck/discussions/145).
 
 ## :bookmark: Labels
 Optionally add labels to compose-files. Currently these are the usable labels:

--- a/README.md
+++ b/README.md
@@ -144,8 +144,11 @@ Further additions are welcome - suggestions or PR!
 <sub><sup>Initiated and first contributed by [yoyoma2](https://github.com/yoyoma2).</sup></sub>  
 
 ### :date: Release notes addon
-There's a function to use a lookup-file to add release note URL's to the notification message and the cli updated container options.  
-Copy the notify_templates/`urls.list` file to the script directory, it will be used automatically if it's there.   Modify it as necessary, the names of interest in the left column needs to match your container names.  
+There's a function to use a lookup-file to add release note URL's to the notification message.  
+Copy the notify_templates/`urls.list` file to the script directory, it will be used automatically if it's there.  
+Modify it as necessary, the names of interest in the left column needs to match your container names.  
+To also list the URL's in the CLI output (choose containers list) use the `-I` option or variable config.  
+
 The output of the notification will look something like this:
 ```
 Containers on hostname with updates available:
@@ -174,7 +177,7 @@ See the [README.md](./addons/prometheus/README.md) for more detailed information
 <sub><sup>Contributed by [tdralle](https://github.com/tdralle).</sup></sub>  
 
 ### :small_orange_diamond: Zabbix config to monitor docker image updates
-If you already use Zabbix - this config will Shows number of available docker image updates on host.   
+If you already use Zabbix - this config will Shows number of available docker image updates on host.  
 Example: *2 Docker Image updates on host-xyz*  
 See project: [thetorminal/zabbix-docker-image-updates](https://github.com/thetorminal/zabbix-docker-image-updates)
 

--- a/default.config
+++ b/default.config
@@ -20,3 +20,4 @@
 #ForceRestartStacks=true    # Force stack restart after update. Caution.
 #DRunUp=true    # Allow updating images for docker run, wont update the container.
 #MonoMode=true    # Monochrome mode, no printf colour codes and hides progress bar.
+#PrintReleaseURL=true   # Prints custom releasenote urls alongside each container with updates (requires urls.list)`

--- a/default.config
+++ b/default.config
@@ -6,17 +6,17 @@
 # This will not be replaced on updates
 
 #Timeout=10    # Set a timeout (in seconds) per container for registry checkups.
-#MaxAsync=1    # Set max asynchronous subprocesses, 1 default, 0 to disable.
+#MaxAsync=10    # Set max asynchronous subprocesses, 1 default, 0 to disable.
 #BarWidth=50    # The character width of the progress bar
 #AutoMode=true    # Automatic updates, without interaction.
 #DontUpdate=true    # No updates; only checking availability without interaction.
-#AutoPrune=false    # Auto-Prune dangling images after update.
-#AutoSelfUpdate    # Allow automatic self updates - caution as this will pull new code and autorun it.
-#Notify=false    # Inform - send a preconfigured notification.
+#AutoPrune=true    # Auto-Prune dangling images after update.
+#AutoSelfUpdate=true    # Allow automatic self updates - caution as this will pull new code and autorun it.
+#Notify=true    # Inform - send a preconfigured notification.
 #Exclude="one,two"    # Exclude containers, separated by comma.
 #DaysOld="5"    # Only update to new images that are N+ days old. Lists too recent with +prefix and age. 2xSlower.
 #Stopped="-a"    # Include stopped containers in the check. (Logic: docker ps -a).
-#OnlyLabel=false    # Only update if label is set. See readme.
-#ForceRestartStacks=false    # Force stack restart after update. Caution.
-#DRunUp=false    # Allow updating images for docker run, wont update the container.
-#MonoMode==false    # Monochrome mode, no printf colour codes and hides progress bar.
+#OnlyLabel=true    # Only update if label is set. See readme.
+#ForceRestartStacks=true    # Force stack restart after update. Caution.
+#DRunUp=true    # Allow updating images for docker run, wont update the container.
+#MonoMode=true    # Monochrome mode, no printf colour codes and hides progress bar.

--- a/default.config
+++ b/default.config
@@ -11,6 +11,7 @@
 #AutoMode=true    # Automatic updates, without interaction.
 #DontUpdate=true    # No updates; only checking availability without interaction.
 #AutoPrune=false    # Auto-Prune dangling images after update.
+#AutoSelfUpdate    # Allow automatic self updates - caution as this will pull new code and autorun it.
 #Notify=false    # Inform - send a preconfigured notification.
 #Exclude="one,two"    # Exclude containers, separated by comma.
 #DaysOld="5"    # Only update to new images that are N+ days old. Lists too recent with +prefix and age. 2xSlower.

--- a/default.config
+++ b/default.config
@@ -18,3 +18,4 @@
 #OnlyLabel=false    # Only update if label is set. See readme.
 #ForceRestartStacks=false    # Force stack restart after update. Caution.
 #DRunUp=false    # Allow updating images for docker run, wont update the container.
+#MonoMode==false    # Monochrome mode, no printf colour codes and hides progress bar.

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -283,11 +283,11 @@ dependency_check() {
           export "$AppVar"="$AppName"
           printf "\n%b%b installed.%b\n" "$c_green" "$AppName" "$c_reset"
         else
-          PkgExitcode="ERROR"
+          PkgInstaller="ERROR"
           printf "\n%bPackagemanager install failed%b, falling back to static binary.\n" "$c_yellow" "$c_reset"
         fi
       fi
-      if [[ "$GetBin" =~ [sS] || "$PkgInstaller" == "ERROR" ]]; then
+      if [[ "$GetBin" =~ [sS] ]] || [[ "$PkgInstaller" == "ERROR" ]]; then
           binary_downloader "$AppName" "$AppUrl"
           [[ -f "$ScriptWorkDir/$AppName" ]] && { export "$AppVar"="$ScriptWorkDir/$1" && printf "\n%b%b downloaded.%b\n" "$c_green" "$AppName" "$c_reset"; }
       fi

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -250,10 +250,11 @@ binary_downloader() {
 }
 
 distro_checker() {
-  if [[ -f /etc/arch-release ]]; then PkgInstaller="pacman -S"
+  if [[ -f /etc/arch-release ]]; then PkgInstaller="sudo pacman -S"
   elif [[ -f /etc/redhat-release ]]; then PkgInstaller="sudo dnf install"
   elif [[ -f /etc/SuSE-release ]]; then PkgInstaller="sudo zypper install"
   elif [[ -f /etc/debian_version ]]; then PkgInstaller="sudo apt-get install"
+  elif [[ -f /etc/alpine-release ]] ; then PkgInstaller="doas apk add"
   elif [[ $(uname -s) == "Darwin" ]]; then PkgInstaller="brew install"
   else PkgInstaller="ERROR"; printf "\n%bNo distribution could be determined%b, falling back to static binary.\n" "$c_yellow" "$c_reset"
   fi
@@ -514,9 +515,9 @@ if [[ -n "${GotUpdates:-}" ]]; then
         ${DockerBin} ${CompleteConfs} ${ContEnvs} up -d ${ContName}
       fi
     done
-    printf "\n%bAll done!%b\n" "$c_green" "$c_reset"
-    if [[ "$AutoPrune" == false ]] && [[ "$AutoMode" == false ]]; then read -r -p "Would you like to prune dangling images? y/[n]: " AutoPrune; fi
+    if [[ "$AutoPrune" == false ]] && [[ "$AutoMode" == false ]]; then read -rep "\nWould you like to prune dangling images? y/[n]: " AutoPrune; fi
     if [[ "$AutoPrune" == true ]] || [[ "$AutoPrune" =~ [yY] ]]; then docker image prune -f; fi
+    printf "\n%bAll done!%b\n" "$c_green" "$c_reset"
   else
     printf "\nNo updates installed, exiting.\n"
   fi

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -84,23 +84,24 @@ c_blue="\033[0;34m"
 c_teal="\033[0;36m"
 c_reset="\033[0m"
 
-while getopts "aynpfrhlisvmc:e:d:t:x:" options; do
+while getopts "ayfhilmnprsuvc:e:d:t:x:" options; do
   case "${options}" in
     a|y) AutoMode=true ;;
     c)   CollectorTextFileDirectory="${OPTARG}" ;;
-    n)   DontUpdate=true; AutoMode=true;;
-    r)   DRunUp=true ;;
-    p)   AutoPrune=true ;;
-    l)   OnlyLabel=true ;;
+    d)   DaysOld=${OPTARG} ;;
+    e)   Exclude=${OPTARG} ;;
     f)   ForceRestartStacks=true ;;
     i)   Notify=true ;;
-    e)   Exclude=${OPTARG} ;;
+    l)   OnlyLabel=true ;;
     m)   MonoMode=true ;;
+    n)   DontUpdate=true; AutoMode=true;;
+    p)   AutoPrune=true ;;
+    r)   DRunUp=true ;;
     s)   Stopped="-a" ;;
     t)   Timeout="${OPTARG}" ;;
+    u)   AutoSelfUpdate=true ;;
     v)   printf "%s\n" "$VERSION"; exit 0 ;;
     x)   MaxAsync=${OPTARG} ;;
-    d)   DaysOld=${OPTARG} ;;
     h|*) Help; exit 2 ;;
   esac
 done

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -137,30 +137,30 @@ self_update_curl() {
   cp "$ScriptPath" "$ScriptPath".bak
   if command -v curl &>/dev/null; then
     curl -L $RawUrl > "$ScriptPath"; chmod +x "$ScriptPath"
-    printf "\n%s\n" "--- starting over with the updated version ---"
+    printf "\n%b---%b starting over with the updated version %b---%b\n" "$c_yellow" "$c_teal" "$c_yellow" "$c_reset"
     exec "$ScriptPath" "${ScriptArgs[@]}" # run the new script with old arguments
     exit 1 # Exit the old instance
   elif command -v wget &>/dev/null; then
     wget $RawUrl -O "$ScriptPath"; chmod +x "$ScriptPath"
-    printf "\n%s\n" "--- starting over with the updated version ---"
+    printf "\n%b---%b starting over with the updated version %b---%b\n" "$c_yellow" "$c_teal" "$c_yellow" "$c_reset"
     exec "$ScriptPath" "${ScriptArgs[@]}" # run the new script with old arguments
     exit 0 # exit the old instance
   else
-    printf "curl/wget not available - download the update manually: %s \n" "$Github"
+    printf "\n%bcurl/wget not available %b- download the update manually: %b%s %b\n" "$c_red" "$c_reset" "$c_teal" "$Github" "$c_reset"
   fi
 }
 
 self_update() {
-  cd "$ScriptWorkDir" || { printf "Path error, skipping update.\n"; return; }
+  cd "$ScriptWorkDir" || { printf "%bPath error,%b skipping update.\n" "$c_red" "$c_reset"; return; }
   if command -v git &>/dev/null && [[ "$(git ls-remote --get-url 2>/dev/null)" =~ .*"mag37/dockcheck".* ]]; then
     printf "\n%s\n" "Pulling the latest version."
-    git pull --force || { printf "Git error, manually pull/clone.\n"; return; }
+    git pull --force || { printf "%bGit error,%b manually pull/clone.\n" "$c_red" "$c_reset"; return; }
     printf "\n%s\n" "--- starting over with the updated version ---"
-    cd - || { printf "Path error.\n"; return; }
+    cd - || { printf "%bPath error.%b\n" "$c_red"; return; }
     exec "$ScriptPath" "${ScriptArgs[@]}" # run the new script with old arguments
     exit 0 # exit the old instance
   else
-    cd - || { printf "Path error.\n"; return; }
+    cd - || { printf "%bPath error.%b\n" "$c_red"; return; }
     self_update_curl
   fi
 }
@@ -184,7 +184,7 @@ choosecontainers() {
       done
     fi
   done
-  printf "\nUpdating containers:\n"
+  printf "\n%bUpdating container(s):%b\n" "$c_blue" "$c_reset"
   printf "%s\n" "${SelectedUpdates[@]}"
   printf "\n"
 }
@@ -487,7 +487,7 @@ if [[ -n "${GotUpdates:-}" ]]; then
         continue
       fi
       # cd to the compose-file directory to account for people who use relative volumes
-      cd "$ContPath" || { echo "Path error - skipping $i"; continue; }
+      cd "$ContPath" || { printf "\n%bPath error - skipping%b %s" "$c_red" "$c_reset" "$i"; continue; }
       ## Reformatting path + multi compose
       if [[ $ContConfigFile = '/'* ]]; then
         CompleteConfs=$(for conf in ${ContConfigFile//,/ }; do printf -- "-f %s " "$conf"; done)

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -271,9 +271,9 @@ dependency_check() {
         [[ $(uname -s) == "Darwin" && "$AppName" == "regctl" ]] && AppName="regclient"
         if $PkgInstaller "$AppName"; then
           AppName="$1"
-          export "$AppVar"="$AppName" 
+          export "$AppVar"="$AppName"
           printf "\n%b%b installed.%b\n" "$c_green" "$AppName" "$c_reset"
-        else 
+        else
           PkgExitcode="ERROR"
           printf "\n%bPackagemanager install failed%b, falling back to static binary.\n" "$c_yellow" "$c_reset"
         fi
@@ -380,7 +380,7 @@ check_image() {
 
 # Make required functions and variables available to subprocesses
 export -f check_image datecheck
-export Excludes_string="${Excludes[*]}" # Can only export scalar variables
+export Excludes_string="${Excludes[*]:-}" # Can only export scalar variables
 export t_out regbin RepoUrl DaysOld
 
 # Check for POSIX xargs with -P option, fallback without async

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -45,7 +45,7 @@ Help() {
   echo "-r     Allow updating images for docker run; won't update the container."
   echo "-s     Include stopped containers in the check. (Logic: docker ps -a)."
   echo "-t     Set a timeout (in seconds) per container for registry checkups, 10 is default."
-  echo "-u     Allow automatic self updates - caution as this will pull new code and autorun it." 
+  echo "-u     Allow automatic self updates - caution as this will pull new code and autorun it."
   echo "-v     Prints current version."
   echo "-x N   Set max asynchronous subprocesses, 1 default, 0 to disable, 32+ tested."
   echo
@@ -431,8 +431,8 @@ unset IFS
 
 # Run the prometheus exporter function
 if [[ -n "${CollectorTextFileDirectory:-}" ]]; then
-  if type -t send_notification &>/dev/null; then
-    prometheus_exporter ${#NoUpdates[@]:-} ${#GotUpdates[@]:-} ${#GotErrors[@]:-}
+  if type -t prometheus_exporter &>/dev/null; then
+    prometheus_exporter ${#NoUpdates[@]} ${#GotUpdates[@]} ${#GotErrors[@]}
   else
     printf "%s\n" "Could not source prometheus exporter function."
   fi

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -38,7 +38,7 @@ Help() {
   echo "-h     Print this Help."
   echo "-i     Inform - send a preconfigured notification."
   echo "-l     Only update if label is set. See readme."
-  echo "-m     Monochrome mode, no printf colour codes."
+  echo "-m     Monochrome mode, no printf colour codes and hides progress bar."
   echo "-n     No updates; only checking availability without interaction."
   echo "-p     Auto-prune dangling images after update."
   echo "-r     Allow updating images for docker run; won't update the container."
@@ -61,6 +61,7 @@ OnlyLabel=${OnlyLabel:=false}
 Notify=${Notify:=false}
 ForceRestartStacks=${ForceRestartStacks:=false}
 DRunUp=${DRunUp:=false}
+MonoMode=${MonoMode:=false}
 Stopped=${Stopped:=""}
 CollectorTextFileDirectory=${CollectorTextFileDirectory:-}
 Exclude=${Exclude:-}
@@ -92,7 +93,7 @@ while getopts "aynpfrhlisvmc:e:d:t:x:" options; do
     f)   ForceRestartStacks=true ;;
     i)   Notify=true ;;
     e)   Exclude=${OPTARG} ;;
-    m)   declare c_{red,green,yellow,blue,teal,reset}="" ;;
+    m)   MonoMode=true ;;
     s)   Stopped="-a" ;;
     t)   Timeout="${OPTARG}" ;;
     v)   printf "%s\n" "$VERSION"; exit 0 ;;
@@ -108,6 +109,7 @@ SearchName="${1:-}"
 
 # Setting up options and sourcing functions
 if [[ "$DontUpdate" == true ]]; then AutoMode=true; fi
+if [[ "$MonoMode" == true ]]; then declare c_{red,green,yellow,blue,teal,reset}=""; fi
 if [[ "$Notify" == true ]]; then
   if [[ -s "${ScriptWorkDir}/notify.sh" ]]; then
     source "${ScriptWorkDir}/notify.sh"
@@ -394,7 +396,7 @@ fi
 # Asynchronously check the image-hash of every running container VS the registry
 while read -r line; do
   ((RegCheckQue+=1))
-  progress_bar "$RegCheckQue" "$ContCount"
+  if [[ "$MonoMode" == false ]]; then progress_bar "$RegCheckQue" "$ContCount"; fi
 
   Got=${line%% *}  # Extracts the first word (NoUpdates, GotUpdates, GotErrors)
   item=${line#* }

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -37,6 +37,7 @@ Help() {
   echo "-f     Force stack restart after update. Caution: restarts once for every updated container within stack."
   echo "-h     Print this Help."
   echo "-i     Inform - send a preconfigured notification."
+  echo "-I     Prints custom releasenote urls alongside each container with updates (requires urls.list)."
   echo "-l     Only update if label is set. See readme."
   echo "-m     Monochrome mode, no printf colour codes and hides progress bar."
   echo "-n     No updates; only checking availability without interaction."
@@ -64,6 +65,7 @@ Notify=${Notify:=false}
 ForceRestartStacks=${ForceRestartStacks:=false}
 DRunUp=${DRunUp:=false}
 MonoMode=${MonoMode:=false}
+PrintReleaseURL=${PrintReleaseURL:=false}
 Stopped=${Stopped:=""}
 CollectorTextFileDirectory=${CollectorTextFileDirectory:-}
 Exclude=${Exclude:-}
@@ -84,7 +86,7 @@ c_blue="\033[0;34m"
 c_teal="\033[0;36m"
 c_reset="\033[0m"
 
-while getopts "ayfhilmnprsuvc:e:d:t:x:" options; do
+while getopts "ayfhiIlmnprsuvc:e:d:t:x:" options; do
   case "${options}" in
     a|y) AutoMode=true ;;
     c)   CollectorTextFileDirectory="${OPTARG}" ;;
@@ -92,6 +94,7 @@ while getopts "ayfhilmnprsuvc:e:d:t:x:" options; do
     e)   Exclude=${OPTARG} ;;
     f)   ForceRestartStacks=true ;;
     i)   Notify=true ;;
+    I)   PrintReleaseURL=true ;;
     l)   OnlyLabel=true ;;
     m)   MonoMode=true ;;
     n)   DontUpdate=true; AutoMode=true;;
@@ -301,7 +304,7 @@ dependency_check() {
 # if urls.list exists add release note url per line
 options() {
   num=1
-  [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("${GotUpdates[@]}")
+  if [[ -s "$ScriptWorkDir/urls.list" ]] && [[ "$PrintReleaseURL" == true ]]; then releasenotes; else Updates=("${GotUpdates[@]}"); fi
   for update in "${Updates[@]}"; do
     echo "$num) $update"
     ((num++))

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -44,6 +44,7 @@ Help() {
   echo "-r     Allow updating images for docker run; won't update the container."
   echo "-s     Include stopped containers in the check. (Logic: docker ps -a)."
   echo "-t     Set a timeout (in seconds) per container for registry checkups, 10 is default."
+  echo "-u     Allow automatic self updates - caution as this will pull new code and autorun it." 
   echo "-v     Prints current version."
   echo "-x N   Set max asynchronous subprocesses, 1 default, 0 to disable, 32+ tested."
   echo
@@ -57,6 +58,7 @@ BarWidth=${BarWidth:=50}
 AutoMode=${AutoMode:=false}
 DontUpdate=${DontUpdate:=false}
 AutoPrune=${AutoPrune:=false}
+AutoSelfUpdate=${AutoSelfUpdate:=false}
 OnlyLabel=${OnlyLabel:=false}
 Notify=${Notify:=false}
 ForceRestartStacks=${ForceRestartStacks:=false}
@@ -308,6 +310,7 @@ if [[ "$VERSION" != "$LatestRelease" ]]; then
   if [[ "$AutoMode" == false ]]; then
     read -r -p "Would you like to update? y/[n]: " SelfUpdate
     [[ "$SelfUpdate" =~ [yY] ]] && self_update
+  elif [[ "$AutoMode" == true ]] && [[ "$AutoSelfUpdate" == true ]]; then self_update;
   else
     [[ "$Notify" == true ]] && { [[ $(type -t dockcheck_notification) == function ]] && dockcheck_notification "$VERSION" "$LatestRelease" "$LatestChanges" || printf "Could not source notification function.\n"; }
   fi

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -413,14 +413,14 @@ done < <( \
 
 # Sort arrays alphabetically
 IFS=$'\n'
-NoUpdates=($(sort <<<"${NoUpdates[*]}"))
-GotUpdates=($(sort <<<"${GotUpdates[*]}"))
+NoUpdates=($(sort <<<"${NoUpdates[*]:-}"))
+GotUpdates=($(sort <<<"${GotUpdates[*]:-}"))
 unset IFS
 
 # Run the prometheus exporter function
 if [[ -n "${CollectorTextFileDirectory:-}" ]]; then
   if type -t send_notification &>/dev/null; then
-    prometheus_exporter ${#NoUpdates[@]} ${#GotUpdates[@]} ${#GotErrors[@]}
+    prometheus_exporter ${#NoUpdates[@]:-} ${#GotUpdates[@]:-} ${#GotErrors[@]:-}
   else
     printf "%s\n" "Could not source prometheus exporter function."
   fi
@@ -430,16 +430,16 @@ fi
 UpdCount="${#GotUpdates[@]}"
 
 # List what containers got updates or not
-if [[ -n ${NoUpdates[*]} ]]; then
+if [[ -n ${NoUpdates[*]:-} ]]; then
   printf "\n%bContainers on latest version:%b\n" "$c_green" "$c_reset"
   printf "%s\n" "${NoUpdates[@]}"
 fi
-if [[ -n ${GotErrors[*]} ]]; then
+if [[ -n ${GotErrors[*]:-} ]]; then
   printf "\n%bContainers with errors, won't get updated:%b\n" "$c_red" "$c_reset"
   printf "%s\n" "${GotErrors[@]}"
   printf "%binfo:%b 'unauthorized' often means not found in a public registry.\n" "$c_blue" "$c_reset"
 fi
-if [[ -n ${GotUpdates[*]} ]]; then
+if [[ -n ${GotUpdates[*]:-} ]]; then
    printf "\n%bContainers with updates available:%b\n" "$c_yellow" "$c_reset"
    [[ "$AutoMode" == false ]] && options || printf "%s\n" "${GotUpdates[@]}"
    [[ "$Notify" == true ]] && { type -t send_notification &>/dev/null && send_notification "${GotUpdates[@]}" || printf "Could not source notification function.\n"; }

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-VERSION="v0.6.1"
-### ChangeNotes: Hotfix - bug with xargs pipefail, pkgmanager logic, unbound variables
+VERSION="v0.6.2"
+### ChangeNotes: Added options: -u; auto self update. -I; print release URL, +style and colour fixes.
 Github="https://github.com/mag37/dockcheck"
 RawUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/dockcheck.sh"
 


### PR DESCRIPTION
- Colour and message style fixes
- `-m` Monochrome mode now also hides progress bar.
- New options:
    - `-u`, allow automatic self update (together with options `-a|y, -n`) caution as this pulls new code and executes.
    - `-I`, lists release note URLs alongside containers with updates (requires `urls.list`)
- Prometheus hotfix
- Pkg manager install fix