### PR TITLE
Detect when there is an error recreating the container

### DIFF
--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -517,7 +517,7 @@ if [[ -n "${GotUpdates:-}" ]]; then
       if [[ "$ContRestartStack" == true ]] || [[ "$ForceRestartStacks" == true ]]; then
         ${DockerBin} ${CompleteConfs} stop; ${DockerBin} ${CompleteConfs} ${ContEnvs} up -d
       else
-        ${DockerBin} ${CompleteConfs} ${ContEnvs} up -d ${ContName}
+        ${DockerBin} ${CompleteConfs} ${ContEnvs} up -d ${ContName} || { printf "\n%bDocker error, exiting!%b\n" "$c_red" "$c_reset" ; exit 1; }
       fi
     done
     if [[ "$AutoPrune" == false ]] && [[ "$AutoMode" == false ]]; then printf "\n"; read -rep "Would you like to prune dangling images? y/[n]: " AutoPrune; fi


### PR DESCRIPTION
The script did not stop when  there is an error recreating the container (in this case, docker-compose.yml was moved to other folder):
```
Now updating (1/1): nginx
latest: Pulling from library/nginx
Digest: sha256:c15da6c91de8d2f436196f3a768483ad32c258ed4e1beb3d367a27ed67253e66
Status: Image is up to date for nginx:latest
docker.io/library/nginx:latest
open /home/foo/bar/docker-compose.yml: no such file or directory

All done!
```
Added an exit for for that case.
Please note this exit stops the loop, consider skipping the container, continue with the rest, and exit with a 1.