### PR TITLE
Enable markdown to notify_ntfy-sh.sh

### DIFF
--- a/notify_templates/notify_ntfy-sh.sh
+++ b/notify_templates/notify_ntfy-sh.sh
@@ -11,10 +11,17 @@ trigger_notification() {
     # Modify to fit your setup:
     NtfyUrl="ntfy.sh/YourUniqueTopicName"
 
+    if [[ "$PrintMarkdownURL" == true ]]; then
+        ContentType="Markdown: yes"
+    else
+        ContentType="Markdown: no" #text/plain
+    fi
+
     curl -sS -o /dev/null --show-error --fail \
       -H "Title: $MessageTitle" \
+      -H "$ContentType"      \
       -d "$MessageBody" \
-      $NtfyUrl
+      "$NtfyUrl"
 }
 
 send_notification() {


### PR DESCRIPTION
As discussed on https://github.com/mag37/dockcheck/pull/170#issuecomment-2849792384 
I have modify notify_ntfy-sh.sh to support markdown. Although, per  https://docs.ntfy.sh/publish/#markdown-formatting Markdown doesn't work on Android/iOS, only Firefox  (or any other browser?)

<details>
  <summary>disclaimer</summary>

This is my first PR so if I messed up anything, my apologies

</details>