### PR TITLE
fix: prevent adding urls when -I is not passed

### DIFF
--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -481,7 +481,7 @@ if [[ -n ${GotUpdates[*]:-} ]]; then
   printf "\n%bContainers with updates available:%b\n" "$c_yellow" "$c_reset"
   if [[ -s "$ScriptWorkDir/urls.list" ]] && [[ "$PrintReleaseURL" == true ]]; then releasenotes; else Updates=("${GotUpdates[@]}"); fi
   [[ "$AutoMode" == false ]] && list_options || printf "%s\n" "${Updates[@]}"
-  [[ "$Notify" == true ]] && { type -t send_notification &>/dev/null && send_notification "${GotUpdates[@]}" || printf "\nCould not source notification function.\n"; }
+  [[ "$Notify" == true ]] && { type -t send_notification &>/dev/null && send_notification "${Updates[@]}" || printf "\nCould not source notification function.\n"; }
 fi
 
 # Optionally get updates if there's any

--- a/notify_templates/notify_DSM.sh
+++ b/notify_templates/notify_DSM.sh
@@ -50,8 +50,7 @@ __EOF
 }
 
 send_notification() {
-		[ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-		UpdToString=$( printf '%s\\n' "${Updates[@]}" )
+		UpdToString=$( printf '%s\\n' "$@" )
 
 		printf "\nSending email notification.\n"
 

--- a/notify_templates/notify_apprise.sh
+++ b/notify_templates/notify_apprise.sh
@@ -23,8 +23,7 @@ trigger_notification() {
 }
 
 send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
+    UpdToString=$( printf '%s\\n' "$@" )
 
     printf "\nSending Apprise notification\n"
 

--- a/notify_templates/notify_discord.sh
+++ b/notify_templates/notify_discord.sh
@@ -16,8 +16,7 @@ trigger_notification() {
 }
 
 send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
+    UpdToString=$( printf '%s\\n' "$@" )
 
     printf "\nSending Discord notification\n"
     # Setting the MessageBody variable here.

--- a/notify_templates/notify_generic.sh
+++ b/notify_templates/notify_generic.sh
@@ -13,8 +13,7 @@ trigger_notification()  {
 }
 
 send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
+    UpdToString=$( printf '%s\\n' "$@" )
 
     # platform specific notification code would go here
     printf "\n%bGeneric notification addon:%b" "$c_green" "$c_reset"

--- a/notify_templates/notify_gotify.sh
+++ b/notify_templates/notify_gotify.sh
@@ -28,8 +28,7 @@ trigger_notification() {
 }
 
 send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
+    UpdToString=$( printf '%s\\n' "$@" )
 
     # platform specific notification code would go here
     printf "\nSending Gotify notification\n"

--- a/notify_templates/notify_matrix.sh
+++ b/notify_templates/notify_matrix.sh
@@ -19,8 +19,7 @@ trigger_notification() {
 }
 
 send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
+    UpdToString=$( printf '%s\\n' "$@" )
 
     # platform specific notification code would go here
     printf "\nSending Matrix notification\n"

--- a/notify_templates/notify_ntfy-sh.sh
+++ b/notify_templates/notify_ntfy-sh.sh
@@ -25,8 +25,7 @@ trigger_notification() {
 }
 
 send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
+    UpdToString=$( printf '%s\\n' "$@" )
 
     printf "\nSending ntfy.sh notification\n"
 

--- a/notify_templates/notify_pushbullet.sh
+++ b/notify_templates/notify_pushbullet.sh
@@ -18,8 +18,7 @@ trigger_notification() {
 }
 
 send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
+    UpdToString=$( printf '%s\\n' "$@" )
 
     # platform specific notification code would go here
     printf "\nSending pushbullet notification\n"

--- a/notify_templates/notify_pushover.sh
+++ b/notify_templates/notify_pushover.sh
@@ -24,8 +24,7 @@ trigger_notification() {
 }
 
 send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
+    UpdToString=$( printf '%s\\n' "$@" )
 
     # platform specific notification code would go here
     printf "\nSending pushover notification\n"

--- a/notify_templates/notify_slack.sh
+++ b/notify_templates/notify_slack.sh
@@ -20,8 +20,7 @@ trigger_notification() {
 }
 
 send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
+    UpdToString=$( printf '%s\\n' "$@" )
 
     printf "\nSending Slack notification\n"
 

--- a/notify_templates/notify_smtp.sh
+++ b/notify_templates/notify_smtp.sh
@@ -39,8 +39,7 @@ __EOF
 }
 
 send_notification() {
-		[ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-		UpdToString=$( printf '%s\\n' "${Updates[@]}" )
+		UpdToString=$( printf '%s\\n' "$@" )
 
 		printf "\nSending email notification.\n"
 

--- a/notify_templates/notify_telegram.sh
+++ b/notify_templates/notify_telegram.sh
@@ -26,8 +26,7 @@ trigger_notification() {
 }
 
 send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
+    UpdToString=$( printf '%s\\n' "$@" )
 
     # platform specific notification code would go here
     printf "\nSending Telegram notification\n"


### PR DESCRIPTION
Address an issue where releasenotes is run in notify.sh when -I is not passed but urls.list is present.

Pass Updates[@] to send_notification to eliminate unnecessary calls to releasenotes in all cases.

My first PR here, so feedback is very welcome. I have made several other modifications of varying size and complexity for my own use, so I'll likely be submitting more shortly. If anything is out of line or against the direction you want for the project, reject away.