### PR TITLE
Refactor notifications and add helper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@
 ___
 ## :bell: Changelog
 
+- **v0.6.5**: Refactored notification logic. See notify_templates/notify_v2.sh for upgrade steps.
+    - Added helper functions to simplify sourcing files and executing functions if they exist.
+    - Created notify_v2.sh wrapper script.
+    - Simplified and consolidated notification logic within notify_v2.sh.
+    - Added support for notification management via environment variables.
+    - Moved notification secrets to dockcheck.config.
 - **v0.6.4**: Restructured the update process - first pulls all updates, then recreates all containers.
     - Added logic to skip update check on non-compose containers (unless `-r` option).
     - Added option `-F` to revert to `compose up -d <ContainerName>` targeting specific container and not the stack.
@@ -126,11 +132,19 @@ Alternatively create an alias where specific flags and values are set.
 Example `alias dc=dockcheck.sh -p -x 10 -t 3`.
 
 ## :loudspeaker: Notifications
-Trigger with the `-i` flag if `notify.sh` is present and configured.  
-Will send a list of containers with updates available and a notification when `dockcheck.sh` itself has an update.  
-Run it scheduled with `-ni` to only get notified when there's updates available!  
+Trigger with the `-i` flag.
+If `notify.sh` is present and configured, it will be used. Otherwise, `notify_v2.sh` will be enabled.
+Will send a list of containers with updates available and a notification when `dockcheck.sh` itself has an update.
+Run it scheduled with `-ni` to only get notified when there's updates available!
 
-Use a `notify_X.sh` template file from the **notify_templates** directory, copy it to `notify.sh` alongside the script, modify it to your needs! (notify.sh is added to .gitignore)  
+Legacy installation and configuration:
+Use a `notify_X.sh` template file from the **notify_templates** directory, copy it to `notify.sh` alongside the script, modify it to your needs! (notify.sh is added to .gitignore)
+
+V2 installation and configuration:
+Remove or rename `notify.sh` if previously configured.
+Uncomment and set the NOTIFY_CHANNELS environment variable in `dockcheck.config` to a space separated string of your desired notification channels to enable.
+Uncomment and set the environment variables related to the enabled notification channels.
+
 **Current templates:**
 - Synology [DSM](https://www.synology.com/en-global/dsm)
 - Email with [mSMTP](https://wiki.debian.org/msmtp) (or deprecated alternative [sSMTP](https://wiki.debian.org/sSMTP))

--- a/default.config
+++ b/default.config
@@ -23,3 +23,49 @@
 #PrintReleaseURL=true   # Prints custom releasenote urls alongside each container with updates (requires urls.list)`
 #PrintMarkdownURL=true    # Prints custom releasenote urls as markdown
 #OnlySpecific=true    # Only compose up the specific container, not the whole compose. (useful for master-compose structure).
+
+### Notify settings
+# All commented values are examples only. Modify as needed.
+#
+# Uncomment the line below and specify the notification channels you wish to enable in a space separated string
+# NOTIFY_CHANNELS="apprise discord DSM generic gotify matrix ntfy-sh pushbullet pushover slack smtp telegram"
+#
+# DISABLE_DOCKCHECK_NOTIFICATION=false
+# DISABLE_NOTIFY_NOTIFICATION=false
+#
+# APPRISE_PAYLOAD='mailto://myemail:mypass@gmail.com
+#                 mastodons://{token}@{host}
+#                 pbul://o.gn5kj6nfhv736I7jC3cj3QLRiyhgl98b
+#                 tgram://{bot_token}/{chat_id}/'
+# APPRISE_URL="http://apprise.mydomain.tld:1234/notify/apprise"
+#
+# DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/<token string>"
+#
+# DSM_SENDMAILTO="me@mydomain.com"
+# DSM_SUBJECTTAG="Email Subject Prefix"
+#
+# GOTIFY_DOMAIN="https://gotify.domain.tld"
+# GOTIFY_TOKEN="token-value"
+#
+# MATRIX_ACCESS_TOKEN="token-value"
+# MATRIX_ROOM_ID="myroom"
+# MATRIX_SERVER_URL="https://matrix.yourdomain.tld"
+#
+# NOTIFY_TOPIC_NAME="YourUniqueTopicName"
+#
+# PUSHBULLET_URL="https://api.pushbullet.com/v2/pushes"
+# PUSHBULLET_TOKEN="token-value"
+#
+# PUSHOVER_URL="https://api.pushover.net/1/messages.json"
+# PUSHOVER_USER_KEY="userkey"
+# PUSHOVER_TOKEN="token-value"
+#
+# SLACK_CHANNEL_ID=mychannel
+# SLACK_ACCESS_TOKEN=xoxb-token-value
+#
+# SMTP_MAIL_FROM="me@mydomain.tld"
+# SMTP_MAIL_TO="you@yourdomain.tld"
+# SMTP_SUBJECT_TAG="dockcheck"
+#
+# TELEGRAM_CHAT_ID="mychatid"
+# TELEGRAM_TOKEN="token-value"

--- a/notify_templates/notify_DSM.sh
+++ b/notify_templates/notify_DSM.sh
@@ -1,11 +1,10 @@
 ### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
-NOTIFY_DSM_VERSION="v0.1"
+NOTIFY_DSM_VERSION="v0.2"
 # INFO: ssmtp is deprecated - consider to use msmtp instead.
 #
-# Copy/rename this file to notify.sh to enable the notification snipppet.
 # mSMTP/sSMTP has to be installed and configured manually.
 # The existing DSM Notification Email configuration will be used automatically.
-# Modify to your liking - changing SendMailTo and Subject and content.
+# Set DSM_SENDMAILTO and DSM_SUBJECTTAG in your dockcheck.config file.
 
 MSMTP=$(which msmtp)
 SSMTP=$(which ssmtp)
@@ -18,18 +17,17 @@ else
 	echo "No msmtp or ssmtp binary found in PATH: $PATH" ; exit 1
 fi
 
-FromHost=$(hostname)
-
-trigger_notification() {
+trigger_DSM_notification() {
 CfgFile="/usr/syno/etc/synosmtp.conf"
 
 # User variables:
 # Automatically sends to your usual destination for synology DSM notification emails.
-# You can also manually override by assigning something else to SendMailTo below.
-SendMailTo=$(grep 'eventmail1' $CfgFile | sed -n 's/.*"\([^"]*\)".*/\1/p')
-#SendMailTo="me@mydomain.com"
+# You can also manually override by assigning something else to DSM_SENDMAILTO in dockcheck.config.
+SendMailTo=${DSM_SENDMAILTO:-$(grep 'eventmail1' $CfgFile | sed -n 's/.*"\([^"]*\)".*/\1/p')}
+# e.g. DSM_SENDMAILTO="me@mydomain.com"
 
-SubjectTag=$(grep 'eventsubjectprefix' $CfgFile | sed -n 's/.*"\([^"]*\)".*/\1/p')
+SubjectTag=${DSM_SUBJECTTAG:-$(grep 'eventsubjectprefix' $CfgFile | sed -n 's/.*"\([^"]*\)".*/\1/p')}
+# e.g. DSM_SUBJECTTAG="Email Subject Prefix"
 SenderName=$(grep 'smtp_from_name' $CfgFile | sed -n 's/.*"\([^"]*\)".*/\1/p')
 SenderMail=$(grep 'smtp_from_mail' $CfgFile | sed -n 's/.*"\([^"]*\)".*/\1/p')
 SenderMail=${SenderMail:-$(grep 'eventmail1' $CfgFile | sed -n 's/.*"\([^"]*\)".*/\1/p')}
@@ -47,36 +45,4 @@ $MessageBody
 __EOF
 # This ensures DSM's container manager will also see the update
 /var/packages/ContainerManager/target/tool/image_upgradable_checker
-}
-
-send_notification() {
-		[ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-		UpdToString=$( printf '%s\\n' "${Updates[@]}" )
-
-		printf "\nSending email notification.\n"
-
-		MessageTitle="Updates available on"
-		# Setting the MessageBody variable here.
-		printf -v MessageBody "🐋 Containers on $FromHost with updates available:\n\n$UpdToString"
-
-		trigger_notification
-}
-
-### Rename (eg. disabled_dockcheck_notification), remove or comment out the following function
-### to not send notifications when dockcheck itself has updates.
-dockcheck_notification() {
-		printf "\nSending email dockcheck notification.\n"
-
-		MessageTitle="New version of dockcheck available on"
-		# Setting the MessageBody variable here.
-		printf -v MessageBody "Installed version: $1\nLatest version: $2\n\nChangenotes: $3\n"
-
-    RawNotifyUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/notify_templates/notify_DSM.sh"
-    LatestNotifyRelease="$(curl -s -r 0-150 $RawNotifyUrl | sed -n "/NOTIFY_DSM_VERSION/s/NOTIFY_DSM_VERSION=//p" | tr -d '"')"
-    if [[ "$NOTIFY_DSM_VERSION" != "$LatestNotifyRelease" ]] ; then
-        printf -v NotifyUpdate "\n\nnotify_DSM.sh update avialable:\n $NOTIFY_DSM_VERSION -> $LatestNotifyRelease\n"
-        MessageBody="${MessageBody}${NotifyUpdate}"
-    fi
-
-		trigger_notification
 }

--- a/notify_templates/notify_apprise.sh
+++ b/notify_templates/notify_apprise.sh
@@ -1,55 +1,24 @@
 ### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
-NOTIFY_APPRISE_VERSION="v0.1"
+NOTIFY_APPRISE_VERSION="v0.2"
 #
-# Copy/rename this file to notify.sh to enable the notification snippet.
 # Required receiving services must already be set up.
-# Modify to fit your setup - if API, set AppriseURL to your Apprise ip/domain.
+# Set any sensitive values via variables in your dockcheck.config file.
+# Set APPRISE_PAYLOAD in your dockcheck.config file.
+# If API, set APPRISE_URL instead.
 
-FromHost=$(hostname)
+trigger_apprise_notification() {
 
-trigger_notification() {
+  if [[ -n "${APPRISE_PAYLOAD:-}" ]]; then
+    apprise -vv -t "$MessageTitle" -b "$MessageBody" \
+      ${APPRISE_PAYLOAD}
+  fi
 
-   ### Modify to fit your setup:
-   apprise -vv -t "$MessageTitle" -b "$MessageBody" \
-      mailto://myemail:mypass@gmail.com \
-      mastodons://{token}@{host} \
-      pbul://o.gn5kj6nfhv736I7jC3cj3QLRiyhgl98b \
-      tgram://{bot_token}/{chat_id}/
+  # e.g. APPRISE_PAYLOAD='mailto://myemail:mypass@gmail.com
+  #                      mastodons://{token}@{host}
+  #                      pbul://o.gn5kj6nfhv736I7jC3cj3QLRiyhgl98b
+  #                      tgram://{bot_token}/{chat_id}/'
 
-   ### If you use the Apprise-API - Comment out the apprise command above.
-   ### Uncomment the AppriseURL and the curl-line below:
-   # AppriseURL="http://apprise.mydomain.tld:1234/notify/apprise"
-   # curl -X POST -F "title=$MessageTitle" -F "body=$MessageBody" -F "tags=all" $AppriseURL
-}
-
-send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
-
-    printf "\nSending Apprise notification\n"
-
-    MessageTitle="$FromHost - updates available."
-    # Setting the MessageBody variable here.
-    printf -v MessageBody "🐋 Containers on $FromHost with updates available:\n$UpdToString"
-
-    trigger_notification
-}
-
-### Rename (eg. disabled_dockcheck_notification), remove or comment out the following function
-### to not send notifications when dockcheck itself has updates.
-dockcheck_notification() {
-    printf "\nSending Apprise dockcheck notification\n"
-
-    MessageTitle="$FromHost - New version of dockcheck available."
-    # Setting the MessageBody variable here.
-    printf -v MessageBody "Installed version: $1 \nLatest version: $2 \n\nChangenotes: $3"
-
-    RawNotifyUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/notify_templates/notify_apprise.sh"
-    LatestNotifyRelease="$(curl -s -r 0-150 $RawNotifyUrl | sed -n "/NOTIFY_APPRISE_VERSION/s/NOTIFY_APPRISE_VERSION=//p" | tr -d '"')"
-    if [[ "$NOTIFY_APPRISE_VERSION" != "$LatestNotifyRelease" ]] ; then
-        printf -v NotifyUpdate "\n\nnotify_apprise.sh update avialable:\n $NOTIFY_APPRISE_VERSION -> $LatestNotifyRelease\n"
-        MessageBody="${MessageBody}${NotifyUpdate}"
-    fi
-
-    trigger_notification
+  if [[ -n "${APPRISE_URL:-}" ]]; then
+    curl -X POST -F "title=$MessageTitle" -F "body=$MessageBody" -F "tags=all" $AppriseURL # e.g. APPRISE_URL=http://apprise.mydomain.tld:1234/notify/apprise
+  fi
 }

--- a/notify_templates/notify_discord.sh
+++ b/notify_templates/notify_discord.sh
@@ -1,43 +1,12 @@
 ### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
-NOTIFY_DISCORD_VERSION="v0.1"
+NOTIFY_DISCORD_VERSION="v0.2"
 #
-# Copy/rename this file to notify.sh to enable the notification snippet.
 # Required receiving services must already be set up.
-# Modify to fit your setup - set DiscordWebhookUrl
+# Set DISCORD_WEBHOOK_URL in your dockcheck.config file.
 
-FromHost=$(hostname)
-
-trigger_notification() {
-    # Modify to fit your setup:
-    DiscordWebhookUrl="PasteYourFullDiscordWebhookURL"
+trigger_discord_notification() {
+    DiscordWebhookUrl="${DISCORD_WEBHOOK_URL}" # e.g. DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/<token string>
 
     MsgBody="{\"username\":\"$FromHost\",\"content\":\"$MessageBody\"}"
     curl -sS -o /dev/null --fail -X POST -H "Content-Type: application/json" -d "$MsgBody" "$DiscordWebhookUrl"
-}
-
-send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
-
-    printf "\nSending Discord notification\n"
-    # Setting the MessageBody variable here.
-    MessageBody="🐋 Containers on $FromHost with updates available: \n$UpdToString"
-
-    trigger_notification
-}
-
-### Rename (eg. disabled_dockcheck_notification), remove or comment out the following function
-### to not send notifications when dockcheck itself has updates.
-dockcheck_notification() {
-    printf "\nSending Discord dockcheck notification\n"
-    MessageBody="$FromHost - New version of dockcheck available: \n Installed version: $1 \nLatest version: $2 \n\nChangenotes: $3"
-
-    RawNotifyUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/notify_templates/notify_discord.sh"
-    LatestNotifyRelease="$(curl -s -r 0-150 $RawNotifyUrl | sed -n "/NOTIFY_DISCORD_VERSION/s/NOTIFY_DISCORD_VERSION=//p" | tr -d '"')"
-    if [[ "$NOTIFY_DISCORD_VERSION" != "$LatestNotifyRelease" ]] ; then
-        printf -v NotifyUpdate "\n\nnotify_discord.sh update avialable:\n $NOTIFY_DISCORD_VERSION -> $LatestNotifyRelease\n"
-        MessageBody="${MessageBody}${NotifyUpdate}"
-    fi
-
-    trigger_notification
 }

--- a/notify_templates/notify_generic.sh
+++ b/notify_templates/notify_generic.sh
@@ -1,44 +1,10 @@
 ### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
-NOTIFY_GENERIC_VERSION="v0.1"
+NOTIFY_GENERIC_VERSION="v0.2"
 #
-# Copy/rename this file to notify.sh to enable the notification snippet.
 # generic sample, the "Hello World" of notification addons
 
-FromHost=$(hostname)
-
-trigger_notification()  {
+trigger_generic_notification()  {
     # Modify to fit your setup:
     printf "\n$MessageTitle\n"
     printf "\n$MessageBody\n"
-}
-
-send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
-
-    # platform specific notification code would go here
-    printf "\n%bGeneric notification addon:%b" "$c_green" "$c_reset"
-    MessageTitle="$FromHost - updates available."
-    printf -v MessageBody "🐋 Containers on $FromHost with updates available:\n$UpdToString"
-
-    trigger_notification
-}
-
-### Rename (eg. disabled_dockcheck_notification), remove or comment out the following function
-### to not send notifications when dockcheck itself has updates.
-dockcheck_notification() {
-    printf "\nGeneric dockcheck notification\n"
-
-    MessageTitle="$FromHost - New version of dockcheck available."
-    # Setting the MessageBody variable here.
-    printf -v MessageBody "Installed version: $1 \nLatest version: $2 \n\nChangenotes: $3"
-
-    RawNotifyUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/notify_templates/notify_generic.sh"
-    LatestNotifyRelease="$(curl -s -r 0-150 $RawNotifyUrl | sed -n "/NOTIFY_GENERIC_VERSION/s/NOTIFY_GENERIC_VERSION=//p" | tr -d '"')"
-    if [[ "$NOTIFY_GENERIC_VERSION" != "$LatestNotifyRelease" ]] ; then
-        printf -v NotifyUpdate "\n\nnotify_generic.sh update avialable:\n $NOTIFY_GENERIC_VERSION -> $LatestNotifyRelease\n"
-        MessageBody="${MessageBody}${NotifyUpdate}"
-    fi
-
-    trigger_notification
 }

--- a/notify_templates/notify_gotify.sh
+++ b/notify_templates/notify_gotify.sh
@@ -1,16 +1,12 @@
 ### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
-NOTIFY_GOTIFY_VERSION="v0.2"
+NOTIFY_GOTIFY_VERSION="v0.3"
 #
-# Copy/rename this file to notify.sh to enable the notification snippet.
 # Required receiving services must already be set up.
-# Modify to fit your setup - set GotifyUrl and GotifyToken.
+# Set GOTIFY_TOKEN and GOTIFY_DOMAIN in your dockcheck.config file.
 
-FromHost=$(hostname)
-
-trigger_notification() {
-    # Modify to fit your setup:
-    GotifyToken="Your Gotify token here"
-    GotifyUrl="https://api.gotify/message?token=${GotifyToken}"
+trigger_gotify_notification() {
+    GotifyToken="${GOTIFY_TOKEN}" # e.g. GOTIFY_TOKEN=token-value
+    GotifyUrl="${GOTIFY_DOMAIN}/message?token=${GotifyToken}" # e.g. GOTIFY_URL=https://gotify.domain.tld
 
     if [[ "$PrintMarkdownURL" == true ]]; then
         ContentType="text/markdown"
@@ -25,37 +21,4 @@ trigger_notification() {
                   '{message: $body, title: $title, priority: 5, extras: {"client::display": {"contentType": $type}}}' )
 
     curl -s -S --data "${JsonData}" -H 'Content-Type: application/json' -X POST "${GotifyUrl}" 1> /dev/null
-}
-
-send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
-
-    # platform specific notification code would go here
-    printf "\nSending Gotify notification\n"
-
-    # Setting the MessageTitle and MessageBody variable here.
-    MessageTitle="${FromHost} - updates available."
-    printf -v MessageBody "Containers on $FromHost with updates available:\n$UpdToString"
-
-    trigger_notification
-}
-
-### Rename (eg. disabled_dockcheck_notification), remove or comment out the following function
-### to not send notifications when dockcheck itself has updates.
-dockcheck_notification() {
-    printf "\nSending Gotify dockcheck notification\n"
-
-    MessageTitle="$FromHost - New version of dockcheck available."
-    # Setting the MessageBody variable here.
-    printf -v MessageBody "Installed version: $1 \nLatest version: $2 \n\nChangenotes: $3"
-
-    RawNotifyUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/notify_templates/notify_gotify.sh"
-    LatestNotifyRelease="$(curl -s -r 0-150 $RawNotifyUrl | sed -n "/NOTIFY_GOTIFY_VERSION/s/NOTIFY_GOTIFY_VERSION=//p" | tr -d '"')"
-    if [[ "$NOTIFY_GOTIFY_VERSION" != "$LatestNotifyRelease" ]] ; then
-        printf -v NotifyUpdate "\n\nnotify_gotify.sh update avialable:\n $NOTIFY_GOTIFY_VERSION -> $LatestNotifyRelease\n"
-        MessageBody="${MessageBody}${NotifyUpdate}"
-    fi
-
-    trigger_notification
 }

--- a/notify_templates/notify_matrix.sh
+++ b/notify_templates/notify_matrix.sh
@@ -1,51 +1,16 @@
 ### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
-NOTIFY_MATRIX_VERSION="v0.1"
+NOTIFY_MATRIX_VERSION="v0.2"
 #
-# Copy/rename this file to notify.sh to enable the notification snippet.
 # Required receiving services must already be set up.
 # Modify to fit your setup - set MatrixServer, Room_id and AccessToken
+# Set MATRIX_ACCESS_TOKEN, MATRIX_ROOM_ID, and MATRIX_SERVER_URL in your dockcheck.config file.
 
-FromHost=$(hostname)
-
-trigger_notification() {
-    # Modify to fit your setup:
-    AccessToken="Your Matrix token here"
-    Room_id="Enter Room_id here"
-    MatrixServer="Enter Your HomeServer URL"
+trigger_matrix_notification() {
+    AccessToken="${MATRIX_ACCESS_TOKEN}" # e.g. MATRIX_ACCESS_TOKEN=token-value
+    Room_id="${MATRIX_ROOM_ID}" # e.g. MATRIX_ROOM_ID=myroom
+    MatrixServer="${MATRIX_SERVER_URL}" # e.g. MATRIX_SERVER_URL=http://matrix.yourdomain.tld
     MsgBody="{\"msgtype\":\"m.text\",\"body\":\"$MessageBody\"}"
 
     # URL Example:  https://matrix.org/_matrix/client/r0/rooms/!xxxxxx:example.com/send/m.room.message?access_token=xxxxxxxx
     curl -sS -o /dev/null --fail -X POST "$MatrixServer/_matrix/client/r0/rooms/$Room_id/send/m.room.message?access_token=$AccessToken" -H 'Content-Type: application/json' -d "$MsgBody"
-}
-
-send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
-
-    # platform specific notification code would go here
-    printf "\nSending Matrix notification\n"
-
-    # Setting the MessageBody variable here.
-    MessageBody="🐋 Containers on $FromHost with updates available: \n$UpdToString"
-
-    trigger_notification
-}
-
-### Rename (eg. disabled_dockcheck_notification), remove or comment out the following function
-### to not send notifications when dockcheck itself has updates.
-dockcheck_notification() {
-    printf "\nSending Matrix dockcheck notification\n"
-
-    MessageTitle="$FromHost - New version of dockcheck available."
-    # Setting the MessageBody variable here.
-    printf -v MessageBody "Installed version: $1 \nLatest version: $2 \n\nChangenotes: $3"
-
-    RawNotifyUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/notify_templates/notify_matrix.sh"
-    LatestNotifyRelease="$(curl -s -r 0-150 $RawNotifyUrl | sed -n "/NOTIFY_MATRIX_VERSION/s/NOTIFY_MATRIX_VERSION=//p" | tr -d '"')"
-    if [[ "$NOTIFY_MATRIX_VERSION" != "$LatestNotifyRelease" ]] ; then
-        printf -v NotifyUpdate "\n\nnotify_matrix.sh update avialable:\n $NOTIFY_MATRIX_VERSION -> $LatestNotifyRelease\n"
-        MessageBody="${MessageBody}${NotifyUpdate}"
-    fi
-
-    trigger_notification
 }

--- a/notify_templates/notify_ntfy-sh.sh
+++ b/notify_templates/notify_ntfy-sh.sh
@@ -1,15 +1,11 @@
 ### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
-NOTIFY_NTFYSH_VERSION="v0.2"
+NOTIFY_NTFYSH_VERSION="v0.3"
 #
-# Copy/rename this file to notify.sh to enable the notification snippet.
 # Setup app and subscription at https://ntfy.sh
-# Use your unique Topic Name in the URL below.
+# Set NOTIFY_TOPIC_NAME in your dockcheck.config file.
 
-FromHost=$(hostname)
-
-trigger_notification() {
-    # Modify to fit your setup:
-    NtfyUrl="ntfy.sh/YourUniqueTopicName"
+trigger_ntfy-sh_notification() {
+    NtfyUrl="ntfy.sh/${NOTIFY_TOPIC_NAME}" # e.g. NTFY_TOPIC_NAME=YourUniqueTopicName
 
     if [[ "$PrintMarkdownURL" == true ]]; then
         ContentType="Markdown: yes"
@@ -22,36 +18,4 @@ trigger_notification() {
       -H "$ContentType"      \
       -d "$MessageBody" \
       "$NtfyUrl"
-}
-
-send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
-
-    printf "\nSending ntfy.sh notification\n"
-
-    MessageTitle="$FromHost - updates available."
-    # Setting the MessageBody variable here.
-    printf -v MessageBody "🐋 Containers on $FromHost with updates available:\n$UpdToString"
-
-    trigger_notification
-}
-
-### Rename (eg. disabled_dockcheck_notification), remove or comment out the following function
-### to not send notifications when dockcheck itself has updates.
-dockcheck_notification() {
-    printf "\nSending ntfy.sh dockcheck notification\n"
-
-    MessageTitle="$FromHost - New version of dockcheck available."
-    # Setting the MessageBody variable here.
-    printf -v MessageBody "Installed version: $1 \nLatest version: $2 \n\nChangenotes: $3"
-
-    RawNotifyUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/notify_templates/notify_ntfy-sh.sh"
-    LatestNotifyRelease="$(curl -s -r 0-150 $RawNotifyUrl | sed -n "/NOTIFY_NTFYSH_VERSION/s/NOTIFY_NTFYSH_VERSION=//p" | tr -d '"')"
-    if [[ "$NOTIFY_NTFYSH_VERSION" != "$LatestNotifyRelease" ]] ; then
-        printf -v NotifyUpdate "\n\nnotify_ntfy-sh.sh update avialable:\n $NOTIFY_NTFYSH_VERSION -> $LatestNotifyRelease\n"
-        MessageBody="${MessageBody}${NotifyUpdate}"
-    fi
-
-    trigger_notification
 }

--- a/notify_templates/notify_pushbullet.sh
+++ b/notify_templates/notify_pushbullet.sh
@@ -1,51 +1,14 @@
 ### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
-NOTIFY_PUSHBULLET_VERSION="v0.1"
+NOTIFY_PUSHBULLET_VERSION="v0.2"
 #
-# Copy/rename this file to notify.sh to enable the notification snippet.
 # Required receiving services must already be set up.
 # Requires jq installed and in PATH.
-# Modify to fit your setup - set Url and Token.
+# Set PUSHBULLET_TOKEN and PUSHBULLET_URL in your dockcheck.config file.
 
-FromHost=$(hostname)
-
-trigger_notification() {
-    # Modify to fit your setup:
-    PushUrl="https://api.pushbullet.com/v2/pushes"
-    PushToken="Your Pushbullet token here"
+trigger_pushbullet_notification() {
+    PushUrl="${PUSHBULLET_URL}" # e.g. PUSHBULLET_URL=https://api.pushbullet.com/v2/pushes
+    PushToken="${PUSHBULLET_TOKEN}" # e.g. PUSHBULLET_TOKEN=token-value
 
     # Requires jq to process json data
     jq -n --arg title "$MessageTitle" --arg body "$MessageBody" '{body: $body, title: $title, type: "note"}' | curl -sS -o /dev/null --show-error --fail -X POST -H "Access-Token: $PushToken" -H "Content-type: application/json" $PushUrl -d @-
-}
-
-send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
-
-    # platform specific notification code would go here
-    printf "\nSending pushbullet notification\n"
-
-    MessageTitle="$FromHost - updates available."
-    # Setting the MessageBody variable here.
-    printf -v MessageBody "🐋 Containers on $FromHost with updates available:\n$UpdToString"
-
-    trigger_notification
-}
-
-### Rename (eg. disabled_dockcheck_notification), remove or comment out the following function
-### to not send notifications when dockcheck itself has updates.
-dockcheck_notification() {
-    printf "\nSending pushbullet dockcheck notification\n"
-
-    MessageTitle="$FromHost - New version of dockcheck available."
-    # Setting the MessageBody variable here.
-    printf -v MessageBody "Installed version: $1 \nLatest version: $2 \n\nChangenotes: $3"
-
-    RawNotifyUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/notify_templates/notify_pushbullet.sh"
-    LatestNotifyRelease="$(curl -s -r 0-150 $RawNotifyUrl | sed -n "/NOTIFY_PUSHBULLET_VERSION/s/NOTIFY_PUSHBULLET_VERSION=//p" | tr -d '"')"
-    if [[ "$NOTIFY_PUSHBULLET_VERSION" != "$LatestNotifyRelease" ]] ; then
-        printf -v NotifyUpdate "\n\nnotify_pushbullet.sh update avialable:\n $NOTIFY_PUSHBULLET_VERSION -> $LatestNotifyRelease\n"
-        MessageBody="${MessageBody}${NotifyUpdate}"
-    fi
-
-    trigger_notification
 }

--- a/notify_templates/notify_pushover.sh
+++ b/notify_templates/notify_pushover.sh
@@ -1,18 +1,14 @@
 ### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
-NOTIFY_PUSHOVER_VERSION="v0.1"
+NOTIFY_PUSHOVER_VERSION="v0.2"
 #
-# Copy/rename this file to notify.sh to enable the notification snippet.
 # Required receiving services must already be set up.
 # Requires jq installed and in PATH.
-# Modify to fit your setup - set Url and Token.
+# Set PUSHOVER_USER_KEY, PUSHOVER_TOKEN, and PUSHOVER_URL in your dockcheck.config file.
 
-FromHost=$(hostname)
-
-trigger_notification() {
-    # Modify to fit your setup:
-    PushoverUrl="https://api.pushover.net/1/messages.json"
-    PushoverUserKey="Your Pushover User Key Here"
-    PushoverToken="Your Pushover API Token Here"
+trigger_pushover_notification() {
+    PushoverUrl="${PUSHOVER_URL}" # e.g. PUSHOVER_URL=https://api.pushover.net/1/messages.json
+    PushoverUserKey="${PUSHOVER_USER_KEY}" # e.g. PUSHOVER_USER_KEY=userkey
+    PushoverToken="${PUSHOVER_TOKEN}" # e.g. PUSHOVER_TOKEN=token-value
 
     # Sending the notification via Pushover
     curl -sS -o /dev/null --show-error --fail -X POST \
@@ -21,37 +17,4 @@ trigger_notification() {
         -F "title=$MessageTitle" \
         -F "message=$MessageBody" \
         $PushoverUrl
-}
-
-send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
-
-    # platform specific notification code would go here
-    printf "\nSending pushover notification\n"
-
-    MessageTitle="$FromHost - updates available."
-    # Setting the MessageBody variable here.
-    printf -v MessageBody "🐋 Containers on $FromHost with updates available:\n$UpdToString"
-
-    trigger_notification
-}
-
-### Rename (eg. disabled_dockcheck_notification), remove or comment out the following function
-### to not send notifications when dockcheck itself has updates.
-dockcheck_notification() {
-    printf "\nSending pushover dockcheck notification\n"
-
-    MessageTitle="$FromHost - New version of dockcheck available."
-    # Setting the MessageBody variable here.
-    printf -v MessageBody "Installed version: $1 \nLatest version: $2 \n\nChangenotes: $3"
-
-    RawNotifyUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/notify_templates/notify_pushover.sh"
-    LatestNotifyRelease="$(curl -s -r 0-150 $RawNotifyUrl | sed -n "/NOTIFY_PUSHOVER_VERSION/s/NOTIFY_PUSHOVER_VERSION=//p" | tr -d '"')"
-    if [[ "$NOTIFY_PUSHOVER_VERSION" != "$LatestNotifyRelease" ]] ; then
-        printf -v NotifyUpdate "\n\nnotify_pushover.sh update avialable:\n $NOTIFY_PUSHOVER_VERSION -> $LatestNotifyRelease\n"
-        MessageBody="${MessageBody}${NotifyUpdate}"
-    fi
-
-    trigger_notification
 }

--- a/notify_templates/notify_slack.sh
+++ b/notify_templates/notify_slack.sh
@@ -1,52 +1,16 @@
 ### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
-NOTIFY_SLACK_VERSION="v0.1"
+NOTIFY_SLACK_VERSION="v0.2"
 #
-# Copy/rename this file to notify.sh in the same directory as dockcheck.sh to enable the notification snippet.
 # Setu app and token at https://api.slack.com/tutorials/tracks/posting-messages-with-curl
-# Add your AccessToken and ChannelID below
+# Set SLACK_ACCESS_TOKEN, and SLACK_CHANNEL_ID in your dockcheck.config file.
 
-FromHost=$(hostname)
-
-trigger_notification() {
-    # Modify to fit your setup:
-    AccessToken="xoxb-not-a-real-token-this-will-not-work"
-    ChannelID="C123456"
+trigger_slack_notification() {
+    AccessToken="${SLACK_ACCESS_TOKEN}" # e.g. SLACK_ACCESS_TOKEN=some-token
+    ChannelID="${SLACK_CHANNEL_ID}" # e.g. CHANNEL_ID=mychannel
     SlackUrl="https://slack.com/api/chat.postMessage"
 
     curl -sS -o /dev/null --show-error --fail \
       -d "text=$MessageBody" -d "channel=$ChannelID" \
       -H "Authorization: Bearer $AccessToken" \
       -X POST $SlackUrl
-}
-
-send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
-
-    printf "\nSending Slack notification\n"
-
-    MessageTitle="$FromHost - updates available."
-    # Setting the MessageBody variable here.
-    printf -v MessageBody "🐋 Containers on $FromHost with updates available:\n$UpdToString"
-
-    trigger_notification
-}
-
-### Rename (eg. disabled_dockcheck_notification), remove or comment out the following function
-### to not send notifications when dockcheck itself has updates.
-dockcheck_notification() {
-    printf "\nSending Slack dockcheck notification\n"
-
-    MessageTitle="$FromHost - New version of dockcheck available."
-    # Setting the MessageBody variable here.
-    printf -v MessageBody "Installed version: $1 \nLatest version: $2 \n\nChangenotes: $3"
-
-    RawNotifyUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/notify_templates/notify_slack.sh"
-    LatestNotifyRelease="$(curl -s -r 0-150 $RawNotifyUrl | sed -n "/NOTIFY_SLACK_VERSION/s/NOTIFY_SLACK_VERSION=//p" | tr -d '"')"
-    if [[ "$NOTIFY_SLACK_VERSION" != "$LatestNotifyRelease" ]] ; then
-        printf -v NotifyUpdate "\n\nnotify_slack.sh update avialable:\n $NOTIFY_SLACK_VERSION -> $LatestNotifyRelease\n"
-        MessageBody="${MessageBody}${NotifyUpdate}"
-    fi
-
-    trigger_notification
 }

--- a/notify_templates/notify_smtp.sh
+++ b/notify_templates/notify_smtp.sh
@@ -1,10 +1,9 @@
 ### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
-NOTIFY_SMTP_VERSION="v0.1"
+NOTIFY_SMTP_VERSION="v0.2"
 # INFO: ssmtp is depcerated - consider to use msmtp instead.
 #
-# Copy/rename this file to notify.sh to enable the notification snipppet.
 # mSMTP/sSMTP has to be installed and configured manually.
-# Modify to fit your setup - changing SendMailFrom, SendMailTo, SubjectTag
+# Set SMTP_MAIL_FROM, SMTP_MAIL_TO, and SMTP_SUBJECT_TAG in your dockcheck.config file.
 
 MSMTP=$(which msmtp)
 SSMTP=$(which ssmtp)
@@ -17,13 +16,10 @@ else
 	echo "No msmtp or ssmtp binary found in PATH: $PATH" ; exit 1
 fi
 
-FromHost=$(hostname)
-
-trigger_notification() {
-# User variables:
-SendMailFrom="me@mydomain.tld"
-SendMailTo="me@mydomain.tld"
-SubjectTag="dockcheck"
+trigger_smtp_notification() {
+SendMailFrom="${SMTP_MAIL_FROM}" # e.g. MAIL_FROM=me@mydomain.tld
+SendMailTo="${SMTP_MAIL_TO}" # e.g. MAIL_TO=me@mydomain.tld
+SubjectTag="${SMTP_SUBJECT_TAG}" # e.g. SUBJECT_TAG=dockcheck
 
 $MailPkg $SendMailTo << __EOF
 From: "$FromHost" <$SendMailFrom>
@@ -36,36 +32,4 @@ Content-Transfer-Encoding: 7bit
 $MessageBody
 
 __EOF
-}
-
-send_notification() {
-		[ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-		UpdToString=$( printf '%s\\n' "${Updates[@]}" )
-
-		printf "\nSending email notification.\n"
-
-		MessageTitle="Updates available on"
-		# Setting the MessageBody variable here.
-		printf -v MessageBody "🐋 Containers on $FromHost with updates available:\n\n$UpdToString"
-
-		trigger_notification
-}
-
-### Rename (eg. disabled_dockcheck_notification), remove or comment out the following function
-### to not send notifications when dockcheck itself has updates.
-dockcheck_notification() {
-		printf "\nSending email dockcheck notification.\n"
-
-		MessageTitle="New version of dockcheck available on"
-		# Setting the MessageBody variable here.
-		printf -v MessageBody "Installed version: $1 \nLatest version: $2 \n\nChangenotes: $3"
-
-    RawNotifyUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/notify_templates/notify_smtp.sh"
-    LatestNotifyRelease="$(curl -s -r 0-150 $RawNotifyUrl | sed -n "/NOTIFY_SMTP_VERSION/s/NOTIFY_SMTP_VERSION=//p" | tr -d '"')"
-    if [[ "$NOTIFY_SMTP_VERSION" != "$LatestNotifyRelease" ]] ; then
-        printf -v NotifyUpdate "\n\nnotify_smtp.sh update avialable:\n $NOTIFY_SMTP_VERSION -> $LatestNotifyRelease\n"
-        MessageBody="${MessageBody}${NotifyUpdate}"
-    fi
-
-		trigger_notification
 }

--- a/notify_templates/notify_telegram.sh
+++ b/notify_templates/notify_telegram.sh
@@ -1,13 +1,10 @@
 ### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
-NOTIFY_TELEGRAM_VERSION="v0.1"
+NOTIFY_TELEGRAM_VERSION="v0.2"
 #
-# Copy/rename this file to notify.sh to enable the notification snippet.
 # Required receiving services must already be set up.
-# Modify to fit your setup - set TelegramChatId and TelegramToken.
+# Set TELEGRAM_CHAT_ID and TELEGRAM_TOKEN in your dockcheck.config file.
 
-FromHost=$(hostname)
-
-trigger_notification() {
+trigger_telegram_notification() {
 
     if [[ "$PrintMarkdownURL" == true ]]; then
         ParseMode="Markdown"
@@ -15,44 +12,11 @@ trigger_notification() {
         ParseMode="HTML"
     fi
 
-    # Modify to fit your setup:
-    TelegramToken="Your Telegram token here"
-    TelegramChatId="Your Telegram ChatId here"
+    TelegramToken="${TELEGRAM_TOKEN}" # e.g. TELEGRAM_TOKEN=token-value
+    TelegramChatId="${TELEGRAM_CHAT_ID}" # e.g. TELEGRAM_CHAT_ID=mychatid
     TelegramUrl="https://api.telegram.org/bot$TelegramToken"
     TelegramTopicID=12345678 ## Set to 0 if not using specific topic within chat
     TelegramData="{\"chat_id\":\"$TelegramChatId\",\"text\":\"$MessageBody\",\"message_thread_id\":\"$TelegramTopicID\",\"disable_notification\": false}"
 
     curl -sS -o /dev/null --fail -X POST "$TelegramUrl/sendMessage" -H 'Content-Type: application/json' -d "$TelegramData"
-}
-
-send_notification() {
-    [ -s "$ScriptWorkDir"/urls.list ] && releasenotes || Updates=("$@")
-    UpdToString=$( printf '%s\\n' "${Updates[@]}" )
-
-    # platform specific notification code would go here
-    printf "\nSending Telegram notification\n"
-
-    # Setting the MessageBody variable here.
-    MessageBody="🐋 Containers on $FromHost with updates available: \n$UpdToString"
-
-    trigger_notification
-}
-
-### Rename (eg. disabled_dockcheck_notification), remove or comment out the following function
-### to not send notifications when dockcheck itself has updates.
-dockcheck_notification() {
-    printf "\nSending Telegram dockcheck notification\n"
-
-    MessageTitle="$FromHost - New version of dockcheck available."
-    # Setting the MessageBody variable here.
-    printf -v MessageBody "$FromHost - New version of dockcheck available.\n\nInstalled version: $1 \nLatest version: $2 \n\nChangenotes: $3"
-
-    RawNotifyUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/notify_templates/notify_telegram.sh"
-    LatestNotifyRelease="$(curl -s -r 0-150 $RawNotifyUrl | sed -n "/NOTIFY_TELEGRAM_VERSION/s/NOTIFY_TELEGRAM_VERSION=//p" | tr -d '"')"
-    if [[ "$NOTIFY_TELEGRAM_VERSION" != "$LatestNotifyRelease" ]] ; then
-        printf -v NotifyUpdate "\n\nnotify_telegram.sh update avialable:\n $NOTIFY_TELEGRAM_VERSION -> $LatestNotifyRelease\n"
-        MessageBody="${MessageBody}${NotifyUpdate}"
-    fi
-
-    trigger_notification
 }

--- a/notify_templates/notify_v2.sh
+++ b/notify_templates/notify_v2.sh
@@ -1,0 +1,75 @@
+NOTIFY_V2_VERSION="v0.1"
+#
+# If migrating from an older notify template, remove your existing notify.sh file.
+# Enable and configure all required notification variables in your dockcheck.config file, e.g.:
+# NOTIFY_CHANNELS=apprise gotify slack
+# SLACK_TOKEN=xoxb-some-token-value
+# GOTIFY_TOKEN=some.token
+
+enabled_notify_channels=( ${NOTIFY_CHANNELS} )
+
+FromHost=$(hostname)
+
+for channel in "${enabled_notify_channels[@]}"; do
+  source_if_exists "${ScriptWorkDir}/notify_templates/notify_${channel}.sh"
+done
+
+send_notification() {
+  [[ -s "$ScriptWorkDir"/urls.list ]] && releasenotes || Updates=("$@")
+  UpdToString=$( printf '%s\\n' "${Updates[@]}" )
+
+  for channel in "${enabled_notify_channels[@]}"; do
+    printf "\nSending ${channel} notification\n"
+
+    MessageTitle="$FromHost - updates available."
+    # Setting the MessageBody variable here.
+    printf -v MessageBody "🐋 Containers on $FromHost with updates available:\n$UpdToString"
+
+    exec_if_exists trigger_${channel}_notification "$@"
+  done
+}
+
+### Set DISABLE_DOCKCHECK_NOTIFICATION=false in dockcheck.config
+### to not send notifications when dockcheck itself has updates.
+dockcheck_notification() {
+  if [[ ! "${DISABLE_DOCKCHECK_NOTIFICATION:-}" = "true" ]]; then
+    echo entered
+    MessageTitle="$FromHost - New version of dockcheck available."
+    # Setting the MessageBody variable here.
+    printf -v MessageBody "Installed version: $1 \nLatest version: $2 \n\nChangenotes: $3"
+
+    if [[ ${#enabled_notify_channels[@]} -gt 0 ]]; then printf "\n"; fi
+    for channel in "${enabled_notify_channels[@]}"; do
+      printf "Sending dockcheck update notification - ${channel}\n"
+      exec_if_exists trigger_${channel}_notification
+    done
+  fi
+}
+
+### Set DISABLE_NOTIFY_UPDATE_NOTIFICATION=false in dockcheck.config
+### to not send notifications when notify scripts themselves have updates.
+notify_update_notification() {
+  if [[ ! "${DISABLE_NOTIFY_UPDATE_NOTIFICATION:-}" = "true" ]]; then
+    update_channels=( "${enabled_notify_channels[@]}" "v2" )
+
+    for notify_script in "${update_channels[@]}"; do
+      upper_channel=$(tr '[:lower:]' '[:upper:]' <<< "$notify_script")
+      VersionVar="NOTIFY_${upper_channel}_VERSION"
+      if [[ -n "${!VersionVar}" ]]; then
+        RawNotifyUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/notify_templates/notify_${notify_script}.sh"
+        LatestNotifyRelease="$(curl -s -r 0-150 $RawNotifyUrl | sed -n "/NOTIFY_${upper_channel}_VERSION/s/NOTIFY_${upper_channel}_VERSION=//p" | tr -d '"')"
+        if [[ "${!VersionVar}" != "$LatestNotifyRelease" ]] ; then
+            MessageTitle="$FromHost - New version of notify_${notify_script}.sh available."
+
+            printf -v MessageBody "\nnotify_${notify_script}.sh update available:\n ${!VersionVar} -> $LatestNotifyRelease\n"
+        fi
+
+        printf "\n"
+        for channel in "${update_channels[@]}"; do
+          printf "Sending notify_${notify_script}.sh update notification - ${channel}\n"
+          exec_if_exists trigger_${channel}_notification
+        done
+      fi
+    done
+  fi
+}


### PR DESCRIPTION
* Add helper functions to simplify sourcing files and executing functions if they exist
* Create notify_v2.sh wrapper script
* Simplify and consolidate notification logic within notify_v2.sh
* Support notification management via environment variables
* Move secrets to dockcheck.config

Goals:
* Do not break existing configurations. A notify.sh file already in place takes priority and must be removed for notify_v2.sh to be used.
* No major change to notifications. In my testing, migrating to the new version with an equivalent configuration resulted in identical notifications to the selected notification channel. There were minor changes to CLI output, e.g. "Sending Slack dockcheck notification" changed to "Sending dockcheck update notification - slack" and additional output was added when notifications for template updates are sent.
* Consolidate duplicated template code in the notify_v2.sh wrapper script.
* Move all sensitive and other customizable values to dockcheck.config so notify template files can be committed, sourced, and used without user modification.

I could use some help testing other notification channels I don't have set up, like Apprise and DSM, if possible. I am still working on a "snooze" extension that relies on this as a base, but I should be able to finish it up if approved. Thoughts and criticism very welcome.