### PR TITLE
Notify_v2.sh bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,27 @@ Run it scheduled with `-ni` to only get notified when there's updates available!
 
 V2 installation and configuration (tag v0.6.5 or later):
 Remove or rename `notify.sh` if previously configured using the legacy method.
+Make certain your project directory is laid out as below. You only need the notify_v2.sh file and any notification templates you wish to enable, but there is no harm in having all of them present.
+```
+ .
+├── notify_templates/
+│   ├── notify_DSM.sh
+│   ├── notify_apprise.sh
+│   ├── notify_discord.sh
+│   ├── notify_generic.sh
+│   ├── notify_gotify.sh
+│   ├── notify_matrix.sh
+│   ├── notify_ntfy-sh.sh
+│   ├── notify_pushbullet.sh
+│   ├── notify_pushover.sh
+│   ├── notify_slack.sh
+│   ├── notify_smtp.sh
+│   ├── notify_telegram.sh
+│   └── notify_v2.sh
+├── dockcheck.config
+├── dockcheck.sh
+└── urls.list         # optional
+```
 Uncomment and set the NOTIFY_CHANNELS environment variable in `dockcheck.config` to a space separated string of your desired notification channels to enable.
 Uncomment and set the environment variables related to the enabled notification channels.
 It is recommended not to make changes directly to the `notify_X.sh` template files and to use only environment variables defined in `dockcheck.config` using this method.

--- a/default.config
+++ b/default.config
@@ -54,6 +54,8 @@
 # MATRIX_ROOM_ID="myroom"
 # MATRIX_SERVER_URL="https://matrix.yourdomain.tld"
 #
+# ntfy.sh or your custom domain with no trailing /
+# NTFY_DOMAIN="ntfy.sh"
 # NTFY_TOPIC_NAME="YourUniqueTopicName"
 #
 # PUSHBULLET_URL="https://api.pushbullet.com/v2/pushes"

--- a/notify_templates/notify_discord.sh
+++ b/notify_templates/notify_discord.sh
@@ -1,5 +1,5 @@
 ### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
-NOTIFY_DISCORD_VERSION="v0.2"
+NOTIFY_DISCORD_VERSION="v0.3"
 #
 # Required receiving services must already be set up.
 # Do not modify this file directly. Set DISCORD_WEBHOOK_URL in your dockcheck.config file.
@@ -13,6 +13,10 @@ fi
 trigger_discord_notification() {
   DiscordWebhookUrl="${DISCORD_WEBHOOK_URL}" # e.g. DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/<token string>
 
-  MsgBody="{\"username\":\"$FromHost\",\"content\":\"$MessageBody\"}"
-  curl -sS -o /dev/null --fail -X POST -H "Content-Type: application/json" -d "$MsgBody" "$DiscordWebhookUrl"
+  JsonData=$( jq -n \
+              --arg username "$FromHost" \
+              --arg body "$MessageBody" \
+              '{"username": $username, "content": $body}' )
+
+  curl -sS -o /dev/null --fail -X POST -H "Content-Type: application/json" -d "$JsonData" "$DiscordWebhookUrl"
 }

--- a/notify_templates/notify_ntfy-sh.sh
+++ b/notify_templates/notify_ntfy-sh.sh
@@ -1,17 +1,20 @@
 ### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
-NOTIFY_NTFYSH_VERSION="v0.3"
+NOTIFY_NTFYSH_VERSION="v0.4"
 #
 # Setup app and subscription at https://ntfy.sh
-# Do not modify this file directly. Set NTFY_TOPIC_NAME in your dockcheck.config file.
+# Do not modify this file directly. Set NTFY_DOMAIN and NTFY_TOPIC_NAME in your dockcheck.config file.
 
-if [[ -z "${NTFY_TOPIC_NAME:-}" ]]; then
+if [[ -z "${NTFY_DOMAIN:-}" ]] || [[ -z "${NTFY_TOPIC_NAME:-}" ]]; then
   printf "Ntfy.sh notification channel enabled, but required configuration variables are missing. Ntfy.sh notifications will not be sent.\n"
 
   remove_channel ntfy-sh
 fi
 
 trigger_ntfy-sh_notification() {
-  NtfyUrl="ntfy.sh/${NTFY_TOPIC_NAME}" # e.g. NTFY_TOPIC_NAME=YourUniqueTopicName
+  NtfyUrl="${NTFY_DOMAIN}/${NTFY_TOPIC_NAME}"
+  # e.g.
+  # NTFY_DOMAIN=ntfy.sh
+  # NTFY_TOPIC_NAME=YourUniqueTopicName
 
   if [[ "$PrintMarkdownURL" == true ]]; then
       ContentType="Markdown: yes"

--- a/notify_templates/notify_telegram.sh
+++ b/notify_templates/notify_telegram.sh
@@ -1,5 +1,5 @@
 ### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
-NOTIFY_TELEGRAM_VERSION="v0.2"
+NOTIFY_TELEGRAM_VERSION="v0.3"
 #
 # Required receiving services must already be set up.
 # Do not modify this file directly. Set TELEGRAM_CHAT_ID and TELEGRAM_TOKEN in your dockcheck.config file.
@@ -21,7 +21,12 @@ trigger_telegram_notification() {
   TelegramChatId="${TELEGRAM_CHAT_ID}" # e.g. TELEGRAM_CHAT_ID=mychatid
   TelegramUrl="https://api.telegram.org/bot$TelegramToken"
   TelegramTopicID=${TELEGRAM_TOPIC_ID:="0"}
-  TelegramData="{\"chat_id\":\"$TelegramChatId\",\"text\":\"$MessageBody\",\"message_thread_id\":\"$TelegramTopicID\",\"disable_notification\": false}"
 
-  curl -sS -o /dev/null --fail -X POST "$TelegramUrl/sendMessage" -H 'Content-Type: application/json' -d "$TelegramData"
+  JsonData=$( jq -n \
+              --arg chatid "$TelegramChatId" \
+              --arg text "$MessageBody" \
+              --arg thread "$TelegramTopicID" \
+              '{"chat_id": $chatid, "text": $text, "message_thread_id": $thread, "disable_notification": false}' )
+
+  curl -sS -o /dev/null --fail -X POST "$TelegramUrl/sendMessage" -H 'Content-Type: application/json' -d "$JsonData"
 }


### PR DESCRIPTION
* Clarify notify_v2.sh usage in README.md

* Fix JSON newline handling in Discord and Telegram channels

* Additional error messages when notification templates fail to be sourced

* Additional variable for self-hosted ntfy.sh domain