### PR TITLE
delete show-error on curl

### DIFF
--- a/notify_templates/notify_ntfy.sh
+++ b/notify_templates/notify_ntfy.sh
@@ -24,7 +24,7 @@ trigger_ntfy_notification() {
       ContentType="Markdown: no" #text/plain
   fi
 
-  curl -sS -o /dev/null --show-error --fail \
+  curl -sS -o /dev/null --fail \
     -H "Title: $MessageTitle" \
     -H "$ContentType"      \
     -d "$MessageBody" \

--- a/notify_templates/notify_pushbullet.sh
+++ b/notify_templates/notify_pushbullet.sh
@@ -18,5 +18,5 @@ trigger_pushbullet_notification() {
   PushToken="${PUSHBULLET_TOKEN}" # e.g. PUSHBULLET_TOKEN=token-value
 
   # Requires jq to process json data
-  "$jqbin" -n --arg title "$MessageTitle" --arg body "$MessageBody" '{body: $body, title: $title, type: "note"}' | curl -sS -o /dev/null --show-error --fail -X POST -H "Access-Token: $PushToken" -H "Content-type: application/json" $PushUrl -d @-
+  "$jqbin" -n --arg title "$MessageTitle" --arg body "$MessageBody" '{body: $body, title: $title, type: "note"}' | curl -sS -o /dev/null --fail -X POST -H "Access-Token: $PushToken" -H "Content-type: application/json" $PushUrl -d @-
 }

--- a/notify_templates/notify_pushover.sh
+++ b/notify_templates/notify_pushover.sh
@@ -19,7 +19,7 @@ trigger_pushover_notification() {
   PushoverToken="${PUSHOVER_TOKEN}" # e.g. PUSHOVER_TOKEN=token-value
 
   # Sending the notification via Pushover
-  curl -sS -o /dev/null --show-error --fail -X POST \
+  curl -sS -o /dev/null --fail -X POST \
       -F "token=$PushoverToken" \
       -F "user=$PushoverUserKey" \
       -F "title=$MessageTitle" \

--- a/notify_templates/notify_slack.sh
+++ b/notify_templates/notify_slack.sh
@@ -17,7 +17,7 @@ trigger_slack_notification() {
   ChannelID="${SLACK_CHANNEL_ID}" # e.g. CHANNEL_ID=mychannel
   SlackUrl="https://slack.com/api/chat.postMessage"
 
-  curl -sS -o /dev/null --show-error --fail \
+  curl -sS -o /dev/null --fail \
     -d "text=$MessageBody" -d "channel=$ChannelID" \
     -H "Authorization: Bearer $AccessToken" \
     -X POST $SlackUrl


### PR DESCRIPTION
Not sure if this was intentional or not, but while I was trouble shooting I noticed that the curl command in notify_ntfy.sh uses `curl -sS --show-error` and `-S` is short for `--show-error` so figure that either should be deleted. My PR deletes `--show-error` from the other templates:

- notify_ntfy.sh 
- notify_pushbullet.sh
- notify_pushover.sh
- notify_slack.sh