### PR TITLE
Add DisplaySourcedFiles variable

### DIFF
--- a/default.config
+++ b/default.config
@@ -26,6 +26,7 @@
 #CurlRetryDelay=1    # Time between curl retries
 #CurlRetryCount=3    # Max number of curl retries
 #CurlConnectTimeout=5    # Time to wait for curl to establish a connection before failing
+#DisplaySourcedFiles=false    # Display what files are being sourced/used
 
 ### Notify settings
 ## All commented values are examples only. Modify as needed.

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -17,7 +17,7 @@ ScriptWorkDir="$(dirname "$ScriptPath")"
 source_if_exists_or_fail() {
   if [[ -s "$1" ]]; then
     source "$1"
-    [[ "${DisplaySourcedFiles:-false}" == true ]] && echo " * ${$1} is being used"
+    [[ "${DisplaySourcedFiles:-false}" == true ]] && echo " * sourced config: ${1}"
     return 0
   else
     return 1

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-VERSION="v0.6.8"
-# ChangeNotes: DisplaySourcedfiles variable displays what configuration files are being used 
+VERSION="v0.6.7"
+# ChangeNotes: snooze feature (see readme), curl arguments, cleanup.n files are being used
 Github="https://github.com/mag37/dockcheck"
 RawUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/dockcheck.sh"
 
@@ -14,21 +14,18 @@ ScriptPath="$(readlink -f "$0")"
 ScriptWorkDir="$(dirname "$ScriptPath")"
 
 # Source helper functions
+DisplaySourcedFiles=false
 source_if_exists() {
-  srcFile="$1"
-  if [[ -s "$srcFile" ]]; then
-    source "$srcFile"
-    DisplaySourcedFiles=${DisplaySourcedFiles:-false}
-    [[ "$DisplaySourcedFiles" == true ]] && echo " * ${srcFile} is being used"
+  if [[ -s "$1" ]]; then
+    source "$1"
+    [[ "$DisplaySourcedFiles" == true ]] && echo " * ${$1} is being used"
   fi
 }
 
 source_if_exists_or_fail() {
-  srcFile="$1"
-  if [[ -s "$srcFile" ]]; then
-    source "$srcFile"
-    DisplaySourcedFiles=${DisplaySourcedFiles:-false}
-    [[ "$DisplaySourcedFiles" == true ]] && echo " * ${srcFile} is being used"
+  if [[ -s "$1" ]]; then
+    source "$1"
+    [[ "$DisplaySourcedFiles" == true ]] && echo " * ${$1} is being used"
   else
     return 1
   fi
@@ -88,7 +85,6 @@ Exclude=${Exclude:-}
 DaysOld=${DaysOld:-}
 OnlySpecific=${OnlySpecific:-false}
 SpecificContainer=${SpecificContainer:-""}
-DisplaySourcedFiles=${DisplaySourcedFiles:-false}
 Excludes=()
 GotUpdates=()
 NoUpdates=()

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 VERSION="v0.6.7"
-# ChangeNotes: snooze feature (see readme), curl arguments, cleanup.n files are being used
+# ChangeNotes: snooze feature (see readme), curl arguments, cleanup.
 Github="https://github.com/mag37/dockcheck"
 RawUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/dockcheck.sh"
 

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -14,18 +14,19 @@ ScriptPath="$(readlink -f "$0")"
 ScriptWorkDir="$(dirname "$ScriptPath")"
 
 # Source helper functions
-DisplaySourcedFiles=false
 source_if_exists() {
   if [[ -s "$1" ]]; then
     source "$1"
-    [[ "$DisplaySourcedFiles" == true ]] && echo " * ${$1} is being used"
+    [[ "${DisplaySourcedFiles:-false}" == true ]] && echo " * ${$1} is being used"
+    return 0
   fi
 }
 
 source_if_exists_or_fail() {
   if [[ -s "$1" ]]; then
     source "$1"
-    [[ "$DisplaySourcedFiles" == true ]] && echo " * ${$1} is being used"
+    [[ "${DisplaySourcedFiles:-false}" == true ]] && echo " * ${$1} is being used"
+    return 0
   else
     return 1
   fi

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-VERSION="v0.6.7"
-# ChangeNotes: snooze feature (see readme), curl arguments, cleanup.
+VERSION="v0.6.8"
+# ChangeNotes: DisplaySourcedfiles variable displays what configuration files are being used 
 Github="https://github.com/mag37/dockcheck"
 RawUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/dockcheck.sh"
 
@@ -15,11 +15,23 @@ ScriptWorkDir="$(dirname "$ScriptPath")"
 
 # Source helper functions
 source_if_exists() {
-  if [[ -s "$1" ]]; then source "$1"; fi
+  srcFile="$1"
+  if [[ -s "$srcFile" ]]; then
+    source "$srcFile"
+    DisplaySourcedFiles=${DisplaySourcedFiles:-false}
+    [[ "$DisplaySourcedFiles" == true ]] && echo " * ${srcFile} is being used"
+  fi
 }
 
 source_if_exists_or_fail() {
-  [[ -s "$1" ]] && source "$1"
+  srcFile="$1"
+  if [[ -s "$srcFile" ]]; then
+    source "$srcFile"
+    DisplaySourcedFiles=${DisplaySourcedFiles:-false}
+    [[ "$DisplaySourcedFiles" == true ]] && echo " * ${srcFile} is being used"
+  else
+    return 1
+  fi
 }
 
 # User customizable defaults
@@ -76,6 +88,7 @@ Exclude=${Exclude:-}
 DaysOld=${DaysOld:-}
 OnlySpecific=${OnlySpecific:-false}
 SpecificContainer=${SpecificContainer:-""}
+DisplaySourcedFiles=${DisplaySourcedFiles:-false}
 Excludes=()
 GotUpdates=()
 NoUpdates=()

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -14,14 +14,6 @@ ScriptPath="$(readlink -f "$0")"
 ScriptWorkDir="$(dirname "$ScriptPath")"
 
 # Source helper functions
-source_if_exists() {
-  if [[ -s "$1" ]]; then
-    source "$1"
-    [[ "${DisplaySourcedFiles:-false}" == true ]] && echo " * ${$1} is being used"
-    return 0
-  fi
-}
-
 source_if_exists_or_fail() {
   if [[ -s "$1" ]]; then
     source "$1"
@@ -33,7 +25,7 @@ source_if_exists_or_fail() {
 }
 
 # User customizable defaults
-source_if_exists_or_fail "${HOME}/.config/dockcheck.config" || source_if_exists "${ScriptWorkDir}/dockcheck.config"
+source_if_exists_or_fail "${HOME}/.config/dockcheck.config" || source_if_exists_or_fail "${ScriptWorkDir}/dockcheck.config"
 
 # Help Function
 Help() {


### PR DESCRIPTION
This PR shows what config files are being sourced. DisplaySourcedFiles is added to toggle this feature. Read "feature" as me being picky so I won't be offended if it isn't approved.

```
$ ./dockcheck.sh -x30 -ni
 * /tmp/1/dc2/dockcheck/dockcheck.config is being used
 * /tmp/1/dc2/dockcheck/notify.sh is being used
New version available! v0.6.8 ⇒ v0.6.7 
 Change Notes: snooze feature (see readme), curl arguments, cleanup. 

Sending ntfy.sh dockcheck notification
```