### PR TITLE
Ntfy.sh and authentication

### DIFF
--- a/default.config
+++ b/default.config
@@ -68,6 +68,7 @@
 ## https://ntfy.sh or your custom domain with https:// and no trailing /
 # NTFY_DOMAIN="https://ntfy.sh"
 # NTFY_TOPIC_NAME="YourUniqueTopicName"
+# NTFY_AUTH=""   # set to either format -> "user:password" OR ":tk_12345678". If using tokens, don't forget the ":"
 #
 # PUSHBULLET_URL="https://api.pushbullet.com/v2/pushes"
 # PUSHBULLET_TOKEN="token-value"

--- a/notify_templates/notify_ntfy.sh
+++ b/notify_templates/notify_ntfy.sh
@@ -24,11 +24,18 @@ trigger_ntfy_notification() {
       ContentType="Markdown: no" #text/plain
   fi
 
+  if [[ -n "${NTFY_AUTH:-}" ]]; then
+    NtfyAuth="-u $NTFY_AUTH"
+  else
+    NtfyAuth=""
+  fi
+
   curl -S -o /dev/null ${CurlArgs} \
     -H "Title: $MessageTitle" \
     -H "$ContentType"      \
     -d "$MessageBody" \
-    "$NtfyUrl"
+    $NtfyAuth \
+    -L "$NtfyUrl"
 
   if [[ $? -gt 0 ]]; then
     NotifyError=true

--- a/notify_templates/notify_ntfy.sh
+++ b/notify_templates/notify_ntfy.sh
@@ -1,5 +1,5 @@
 ### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
-NOTIFY_NTFYSH_VERSION="v0.5"
+NOTIFY_NTFYSH_VERSION="v0.6"
 #
 # Setup app and subscription at https://ntfy.sh
 # Leave (or place) this file in the "notify_templates" subdirectory within the same directory as the main dockcheck.sh script.


### PR DESCRIPTION
This solves https://github.com/mag37/dockcheck/issues/206 

https://github.com/mag37/dockcheck/issues/206#issuecomment-3156687001 has:
``` bash
 if [[ -n "${NTFY_AUTH:-}" ]]; then
  NtfyAuth="-u $NTFY_AUTH"
else
  NtfyAuth=""

  curl -S -o /dev/null ${CurlArgs} \
    -H "Title: $MessageTitle" \
    -H "$ContentType"      \
    -d "$MessageBody" \
    "$NtfyUrl" \
    ${NtfyAuth} 
```

A `fi` is missing, and at the bottom `$NtfyURL` shouldn't be enclosed in double quotes because it is passed with single quotes to curl
example: `curl ...  '-u :tk0klj3ekl32e23jk23j4l23'`

I also added an `-L` before the `NtfyUrl`. I use it to make more clean the code to show where the url is, but I'm not sure it all versions of curls have it. Feel free to not add it
