### PR TITLE
Add file notification channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 regctl
 # ignore snooze file
 snooze.list
+# ignore updates file
+updates_available.txt

--- a/default.config
+++ b/default.config
@@ -32,7 +32,7 @@
 ## All commented values are examples only. Modify as needed.
 ##
 ## Uncomment the line below and specify the notification channels you wish to enable in a space separated string
-# NOTIFY_CHANNELS="apprise discord DSM generic HA gotify matrix ntfy pushbullet pushover slack smtp telegram"
+# NOTIFY_CHANNELS="apprise discord DSM file generic HA gotify matrix ntfy pushbullet pushover slack smtp telegram"
 #
 ## Uncomment the line below and specify the number of seconds to delay notifications to enable snooze
 # SNOOZE_SECONDS=86400

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-VERSION="v0.7.0"
-# ChangeNotes: Snooze bugfix, added auth support to ntfy.sh and sendmail support to SMTP
+VERSION="v0.7.1"
+# ChangeNotes: Call send_notification even when no updates are available to write to file (if enabled) and clean up snooze
 Github="https://github.com/mag37/dockcheck"
 RawUrl="https://raw.githubusercontent.com/mag37/dockcheck/main/dockcheck.sh"
 
@@ -507,6 +507,8 @@ if [[ -n ${GotUpdates[*]:-} ]]; then
   if [[ -s "$ScriptWorkDir/urls.list" ]] && [[ "$PrintReleaseURL" == true ]]; then releasenotes; else Updates=("${GotUpdates[@]}"); fi
   [[ "$AutoMode" == false ]] && list_options || printf "%s\n" "${Updates[@]}"
   [[ "$Notify" == true ]] && { exec_if_exists_or_fail send_notification "${GotUpdates[@]}" || printf "\nCould not source notification function.\n"; }
+else
+  [[ "$Notify" == true ]] && [[ ! -s "${ScriptWorkDir}/notify.sh" ]] && { exec_if_exists_or_fail send_notification "${GotUpdates[@]}" || printf "\nCould not source notification function.\n"; }
 fi
 
 # Optionally get updates if there's any

--- a/notify_templates/notify_file.sh
+++ b/notify_templates/notify_file.sh
@@ -1,0 +1,12 @@
+### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
+NOTIFY_FILE_VERSION="v0.1"
+#
+# Leave (or place) this file in the "notify_templates" subdirectory within the same directory as the main dockcheck.sh script.
+# If you instead wish make your own modifications, make a copy in the same directory as the main dockcheck.sh script.
+
+trigger_file_notification() {
+  NotifyFile="${ScriptWorkDir}/updates_available.txt"
+
+  echo "${MessageBody}" > ${NotifyFile}
+
+}

--- a/notify_templates/notify_v2.sh
+++ b/notify_templates/notify_v2.sh
@@ -189,9 +189,11 @@ dockcheck_notification() {
 
       if [[ ${#enabled_notify_channels[@]} -gt 0 ]]; then printf "\n"; fi
       for channel in "${enabled_notify_channels[@]}"; do
-        printf "Sending dockcheck update notification - ${channel}\n"
-        exec_if_exists_or_fail trigger_${channel}_notification || \
-        printf "Attempted to send notification to channel ${channel}, but the function was not found. Make sure notify_${channel}.sh is available in the ${ScriptWorkDir} directory or notify_templates subdirectory.\n"
+        if [[ ! "${channel}" == "file" ]]; then
+          printf "Sending dockcheck update notification - ${channel}\n"
+          exec_if_exists_or_fail trigger_${channel}_notification || \
+          printf "Attempted to send notification to channel ${channel}, but the function was not found. Make sure notify_${channel}.sh is available in the ${ScriptWorkDir} directory or notify_templates subdirectory.\n"
+        fi
       done
 
       [[ -n "${snooze}" ]] && [[ "${NotifyError}" == "false" ]] && update_snooze "dockcheck.sh"


### PR DESCRIPTION
Adds a new "file" notification channel that writes out to a file in the main script project directory. This is intended to slightly more officially support the API implementation discussed here: https://github.com/mag37/dockcheck/discussions/146, although I'm pretty sure the Python API implementation itself is outside the scope of anything that would be included in this repository.

- Writes a comma separated list of container names (and release notes URLs, if enabled) with updates available to updates_available.txt in the main script directory
- Bypasses snooze to make sure the file and API always have the most up-to-date information available
- Bypass the file channel for other notification types (there may be a better, more flexible way of doing this)
- Adds a notify_v2+ exclusive call when there are no updates available to keep the snooze and updates files current
- .gitignore update for updates_available.txt file