### PR TITLE
Label rework + clearer messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Options:
 -h     Print this Help.
 -i     Inform - send a preconfigured notification.
 -I     Prints custom releasenote urls alongside each container with updates in CLI output (requires urls.list).
--l     Only update if label is set. See readme.
+-l     Only include containers with label set. See readme.
 -m     Monochrome mode, no printf colour codes and hides progress bar.
 -M     Prints custom releasenote urls as markdown (requires template support).
 -n     No updates, only checking availability.
@@ -283,9 +283,11 @@ Optionally add labels to compose-files. Currently these are the usable labels:
       mag37.dockcheck.only-specific-container: true
       mag37.dockcheck.restart-stack: true
 ```
-- `mag37.dockcheck.update: true` will when used with the `-l` option only update containers with this label and skip the rest. Will still list updates as usual.
+- `mag37.dockcheck.update: true` will when used with the `-l` option only check and update containers with this label set and skip the rest.  
 - `mag37.dockcheck.only-specific-container: true` works instead of the `-F` option, specifying the updated container when doing compose up, like `docker compose up -d homer`.
 - `mag37.dockcheck.restart-stack: true` works instead of the `-f` option, forcing stop+restart on the whole compose-stack (Caution: Will restart on every updated container within stack).
+
+Adding or modifying labels in compose-files requires a restart of the container to take effect.
 
 ## Workaround for non **amd64** / **arm64**
 `regctl` provides binaries for amd64/arm64, to use on other architecture you could try this workaround.

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -600,7 +600,7 @@ if [[ -n "${GotUpdates:-}" ]]; then
         ${DockerBin} ${CompleteConfs} ${ContEnvs} up -d ${SpecificContainer} || { printf "\n%bDocker error, exiting!%b\n" "$c_red" "$c_reset" ; exit 1; }
       fi
     done
-    if [[ "$AutoPrune" == false ]] && [[ "$AutoMode" == false ]]; then printf "\n"; read -rep "Would you like to prune dangling images? y/[n]: " AutoPrune; fi
+    if [[ "$AutoPrune" == false ]] && [[ "$AutoMode" == false ]]; then printf "\n"; read -rep "Would you like to prune all dangling images? y/[n]: " AutoPrune; fi
     if [[ "$AutoPrune" == true ]] || [[ "$AutoPrune" =~ [yY] ]]; then printf "\nAuto pruning.."; docker image prune -f; fi
     printf "\n%bAll done!%b\n" "$c_green" "$c_reset"
   else

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -482,7 +482,7 @@ done < <( \
   xargs $XargsAsync -I {} bash -c 'check_image "{}"' \
 )
 
-[[ "$OnlyLabel" == true ]] && printf "\n%bLabel option set:%b Only checking containers with labels set.\n" "$c_blue" "$c_reset"
+[[ "$OnlyLabel" == true ]] && printf "\n%bLabel option active:%b Only checking containers with labels set.\n" "$c_blue" "$c_reset"
 
 # Sort arrays alphabetically
 IFS=$'\n'

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -42,7 +42,7 @@ Help() {
   echo "-h     Print this Help."
   echo "-i     Inform - send a preconfigured notification."
   echo "-I     Prints custom releasenote urls alongside each container with updates in CLI output (requires urls.list)."
-  echo "-l     Only update if label is set. See readme."
+  echo "-l     Only include containers with label set. See readme."
   echo "-m     Monochrome mode, no printf colour codes and hides progress bar."
   echo "-M     Prints custom releasenote urls as markdown (requires template support)."
   echo "-n     No updates; only checking availability without interaction."


### PR DESCRIPTION
- Moved up label check and logic to earlier in the process, to iterate the whole run the same way if `-l` option is passed.
- Added messaging to make it clearer.
- Clarified Readme and --help message.
- Clarified prune message (to mean ALL dangling, not just currently updated).