### PR TITLE
Fix version check condition

### DIFF
--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -358,7 +358,7 @@ list_options() {
 }
 
 # Version check & initiate self update
-if [[ "$LatestRelease" != "undefined" ]]; then
+if [[ "$LatestSnippet" != "undefined" ]]; then
   if [[ "$VERSION" != "$LatestRelease" ]]; then
     printf "New version available! %b%s%b ⇒ %b%s%b \n Change Notes: %s \n" "$c_yellow" "$VERSION" "$c_reset" "$c_green" "$LatestRelease" "$c_reset" "$LatestChanges"
     if [[ "$AutoMode" == false ]]; then


### PR DESCRIPTION
Happens to me had a misconfigured DNS, which resulted in a bug where `dockcheck.sh` always detects a new version and replaces itself with a blank file.

A quick investigation showed that this snippet never produces `"$LatestRelease" == "undefined"` and instead `undefined` is only assigned to `"$LatestSnippet"`
```bash
# Check if there's a new release of the script
LatestSnippet="$(curl ${CurlArgs} -r 0-200 "$RawUrl" || printf "undefined")"
LatestRelease="$(echo "${LatestSnippet}" | sed -n "/VERSION/s/VERSION=//p" | tr -d '"')"
LatestChanges="$(echo "${LatestSnippet}" | sed -n "/ChangeNotes/s/# ChangeNotes: //p")"
```