### PR TITLE
ProposedFix down+up instead of stop+up

### DIFF
--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -648,7 +648,7 @@ if [[ -n "${GotUpdates:-}" ]]; then
         ContRestartStack=$($jqbin -r '."mag37.dockcheck.restart-stack"' <<< "$ContLabels")
         [[ "$ContRestartStack" == "null" ]] && ContRestartStack=""
         ContOnlySpecific=$($jqbin -r '."mag37.dockcheck.only-specific-container"' <<< "$ContLabels")
-        [[ "$ContOnlySpecific" == "null" ]] && ContRestartStack=""
+        [[ "$ContOnlySpecific" == "null" ]] && ContOnlySpecific=""
         ContStateRunning=$($jqbin -r '."State"."Running"' <<< "$ContConfig")
         [[ "$ContStateRunning" == "null" ]] && ContStateRunning=""
 
@@ -678,7 +678,7 @@ if [[ -n "${GotUpdates:-}" ]]; then
 
         # Check if the whole stack should be restarted
         if [[ "$ContRestartStack" == true ]] || [[ "$ForceRestartStacks" == true ]]; then
-          ${DockerBin} ${CompleteConfs} stop; ${DockerBin} ${CompleteConfs} ${ContEnvs} up -d || { printf "\n%bDocker error, exiting!%b\n" "$c_red" "$c_reset" ; exit 1; }
+          ${DockerBin} ${CompleteConfs} down; ${DockerBin} ${CompleteConfs} ${ContEnvs} up -d || { printf "\n%bDocker error, exiting!%b\n" "$c_red" "$c_reset" ; exit 1; }
         else
           ${DockerBin} ${CompleteConfs} ${ContEnvs} up -d ${SpecificContainer} || { printf "\n%bDocker error, exiting!%b\n" "$c_red" "$c_reset" ; exit 1; }
         fi


### PR DESCRIPTION
Changed restart stack scenario to compose down + compose up, instead of compose stop + compose up.
Also changed the handling of the missing mag37.dockcheck.only-specific-container label, which would reset the ContRestartStack variable.

As discussed in [issue 265](https://github.com/mag37/dockcheck/issues/265)