### PR TITLE
Allow ranges to be used for selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Containers with updates available:
 03) whoogle-search
 
 Choose what containers to update:
-Enter number(s) separated by comma or range(s) (e.g. 1-2,4-5), [a] for all - [q] to quit: 1-2
+Enter number(s) or range(s) separated by comma (e.g. 1-2,4-5,09), [a] for all - [q] to quit: 1-2
 ```
 
 Then it proceeds to run `pull` and `up -d` on every container with updates.  

--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -229,7 +229,7 @@ self_update() {
 
 choosecontainers() {
   while [[ -z "${ChoiceClean:-}" ]]; do
-    read -r -p "Enter number(s) separated by comma or range(s) (e.g. 1-2,4-5), [a] for all - [q] to quit: " Choice
+    read -r -p "Enter number(s) or range(s) separated by comma (e.g. 1-2,4-5,09), [a] for all - [q] to quit: " Choice
     if [[ "$Choice" =~ [qQnN] ]]; then
       [[ -n "${BackupForDays:-}" ]] && remove_backups
       exit 0


### PR DESCRIPTION
Hi all,

I built this small feature for myself and wanted to share it with the rest of you.

`Choose what containers to update.
Enter number(s) separated by comma or range(s) (e.g. 1-3,4-5), [a] for all - [q] to quit: 2-22
`

Let me know if I need to adjust anything before it can be merged.

Cheers

Max