### PR TITLE
Bugfix and tag support in Apprise template + extras.

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,19 +238,19 @@ Further additions are welcome - suggestions or PRs!
 All required environment variables for each notification channel are provided in the default.config file as comments and must be uncommented and modified for your requirements.  
 For advanced users, additional functionality is available via custom configurations and environment variables.  
 Use cases - all configured in `dockcheck.config`:  
-(replace `<channel>` with the upper case name of the of the channel as listed in
+(replace `<CHANNEL>` with the upper case name of the of the channel as listed in
 `NOTIFY_CHANNELS` variable, eg `TELEGRAM_SKIPSNOOZE`)
 
-- To bypass the snooze feature, even when enabled, add the variable `<channel>_SKIPSNOOZE` and set it to `true`.
-- To configure the channel to only send container update notifications, add the variable `<channel>_CONTAINERSONLY` and set it to `true`.
-- To send notifications even when there are no updates available, add the variable `<channel>_ALLOWEMPTY`  and set it to `true`.
-- To use another notification output format, add the variable `<channel>_OUTPUT` and set it to `csv`, `json`, or `text`. If unset or set to an invalid value, defaults to `text`.
+- To bypass the snooze feature, even when enabled, add the variable `<CHANNEL>_SKIPSNOOZE` and set it to `true`.
+- To configure the channel to only send container update notifications, add the variable `<CHANNEL>_CONTAINERSONLY` and set it to `true`.
+- To send notifications even when there are no updates available, add the variable `<CHANNEL>_ALLOWEMPTY`  and set it to `true`.
+- To use another notification output format, add the variable `<CHANNEL>_OUTPUT` and set it to `csv`, `json`, or `text`. If unset or set to an invalid value, defaults to `text`.
 - To send multiple notifications using the same notification template:
   - Strings in the `NOTIFY_CHANNELS` list are now treated as unique names and do not necessarily refer to the notification template that will be called, though they do by default.
   - Add another notification channel to `NOTIFY_CHANNELS` in `dockcheck.config`. The name can contain upper and lower case letters, numbers and underscores, but can't start with a number.
-  - Add the variable `<channel>_TEMPLATE` to `dockcheck.config` where `<channel>` is the name of the channel added above and set the value to an available notification template script (`slack`, `apprise`, `gotify`, etc.)
-  - Add all other environment variables required for the chosen template to function with `<channel>` in upper case as the prefix rather than the template name.
-    - For example, if `<channel>` is `mynotification` and the template configured is `slack`, you would need to set `MYNOTIFICATION_CHANNEL_ID` and `MYNOTIFICATION_ACCESS_TOKEN`.
+  - Add the variable `<CHANNEL>_TEMPLATE` to `dockcheck.config` where `<CHANNEL>` is the name of the channel added above and set the value to an available notification template script (`slack`, `apprise`, `gotify`, etc.)
+  - Add all other environment variables required for the chosen template to function with `<CHANNEL>` in upper case as the prefix rather than the template name.
+    - For example, if `<CHANNEL>` is `mynotification` and the template configured is `slack`, you would need to set `MYNOTIFICATION_CHANNEL_ID` and `MYNOTIFICATION_ACCESS_TOKEN`.
 
 #### Release notes addon
 

--- a/default.config
+++ b/default.config
@@ -51,6 +51,7 @@
 #                 pbul://o.gn5kj6nfhv736I7jC3cj3QLRiyhgl98b
 #                 tgram://{bot_token}/{chat_id}/'
 # APPRISE_URL="http://apprise.mydomain.tld:1234/notify/apprise"
+# APPRISE_TAG="one_tag,othertag" # Only works with the URL API and need to setup tags within Apprise
 #
 # BARK_KEY="key-value"
 #

--- a/notify_templates/notify_apprise.sh
+++ b/notify_templates/notify_apprise.sh
@@ -1,5 +1,5 @@
 ### DISCLAIMER: This is a third party addition to dockcheck - best effort testing.
-NOTIFY_APPRISE_VERSION="v0.4"
+NOTIFY_APPRISE_VERSION="v0.5"
 #
 # Required receiving services must already be set up.
 # Leave (or place) this file in the "notify_templates" subdirectory within the same directory as the main dockcheck.sh script.
@@ -35,14 +35,9 @@ trigger_apprise_notification() {
     fi
   fi
 
-  # e.g. APPRISE_PAYLOAD='mailto://myemail:mypass@gmail.com
-  #                      mastodons://{token}@{host}
-  #                      pbul://o.gn5kj6nfhv736I7jC3cj3QLRiyhgl98b
-  #                      tgram://{bot_token}/{chat_id}/'
-
   if [[ -n "${!AppriseUrlVar:-}" ]]; then
     AppriseURL="${!AppriseUrlVar}"
-    curl -S -o /dev/null ${CurlArgs} -X POST -F "title=$MessageTitle" -F "body=$MessageBody" -F "tags=all" $AppriseURL # e.g. APPRISE_URL=http://apprise.mydomain.tld:1234/notify/apprise
+    curl -S -o /dev/null ${CurlArgs} -X POST -F "title=$MessageTitle" -F "body=$MessageBody" -F "tags=${APPRISE_TAG:-all}" "$AppriseURL"
 
     if [[ $? -gt 0 ]]; then
       NotifyError=true


### PR DESCRIPTION
Fixes a bug in the Apprise template where the URL sometimes broke due to not being quoted.
At the same time adding proper support for apprise tags within the `default.config` and apprise-template.

Also clarifying the readme to have the correct (upper) case in the notification settings variables.