### PR TITLE
fix: avoid printf escape expansion in dockcheck update body

### DIFF
--- a/notify_templates/notify_v2.sh
+++ b/notify_templates/notify_v2.sh
@@ -321,7 +321,7 @@ dockcheck_notification() {
         format_output "dockcheck_update" "$(output_format "${channel}")" "Installed version: <insert_text_iv>\nLatest version: <insert_text_lv>\n\nChangenotes: <insert_text_rn>\n" "$1" "$2" "$3"
 
         # Setting the MessageBody variable here.
-        printf -v MessageBody "${FormattedOutput}"
+        printf -v MessageBody "%s" "${FormattedOutput}"
 
         printf "\nSending dockcheck update notification - ${channel}"
         exec_if_exists_or_fail trigger_${template}_notification "${channel}" || \


### PR DESCRIPTION
Fixes #278

`dockcheck_notification()` was assigning `FormattedOutput` with `printf -v MessageBody "${FormattedOutput}"`, which interprets escape sequences and breaks JSON output for file notifications. This switches to `printf -v MessageBody "%s" "${FormattedOutput}"` so escaped quotes are preserved as-is.

Greetings, saschabuehrle