### PR TITLE
fix: resolve unbound variable error

### DIFF
--- a/dockcheck.sh
+++ b/dockcheck.sh
@@ -26,7 +26,7 @@ source_if_exists_or_fail() {
 }
 
 # Source user customizable config file
-if [[ ! ${ScriptArgs[*]} =~ "-C" ]]; then
+if [[ ! ${ScriptArgs[*]:-} =~ "-C" ]]; then
   source_if_exists_or_fail "${HOME}/.config/dockcheck.config" || source_if_exists_or_fail "${ScriptWorkDir}/dockcheck.config"
 fi
 


### PR DESCRIPTION
- Fixes Bash <4.4 error when ScriptArgs is empty

Hi, please allow this small fix for my amazing QNAP Bash environment... 😫 